### PR TITLE
Enable github action for building packages for CentOS Stream 8

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,4 @@
-name: PR Checking
+name: PR General Checking
 
 on: [pull_request]
 

--- a/.github/workflows/pr-test-build-centos-stream-8.yml
+++ b/.github/workflows/pr-test-build-centos-stream-8.yml
@@ -1,0 +1,20 @@
+name: PR Test Building Package for CentOS Stream 8
+
+on:
+  pull_request:
+    paths:
+    - 'build/centos-stream-8/**'
+
+jobs:
+  build-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - name: Build grub
+        uses: ./build/centos-stream-8/pkg-builder
+        with:
+          package: intel-mvp-tdx-guest-grub2
+      - name: Build shim package
+        uses: ./build/centos-stream-8/pkg-builder
+        with:
+          package: intel-mvp-tdx-guest-shim

--- a/build/centos-stream-8/pkg-builder/Dockerfile
+++ b/build/centos-stream-8/pkg-builder/Dockerfile
@@ -1,0 +1,16 @@
+from quay.io/centos/centos:stream8
+
+ARG buildreqs="bzip2 coreutils cpio diffutils \
+               gcc gcc-c++ make patch python3 python3-pyyaml \
+               python3-requests redhat-rpm-config \
+               rpm-build unzip which git wget sudo"
+
+COPY aliyun.repo /etc/yum.repos.d/
+
+RUN dnf -y --setopt="tsflags=nodocs" update --allowerasing && \
+    dnf -y --setopt="tsflags=nodocs" install --allowerasing $buildreqs && \
+    dnf clean all && rm -rf /var/cache/yum/
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/build/centos-stream-8/pkg-builder/action.yml
+++ b/build/centos-stream-8/pkg-builder/action.yml
@@ -1,0 +1,12 @@
+# action.yml
+name: 'Builder for CentOS Stream 8'
+description: 'Build the RPM package in CentOS Stream 8 environment'
+inputs:
+  package:  # id of input
+    description: 'The package for build'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.package }}

--- a/build/centos-stream-8/pkg-builder/aliyun.repo
+++ b/build/centos-stream-8/pkg-builder/aliyun.repo
@@ -1,0 +1,28 @@
+[baseos-aliyun]
+name=Aliyun CentOS Steam $releasever - BaseOS
+baseurl=http://mirrors.aliyun.com/centos/$stream/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[appstream-aliyun]
+name=Aliyun CentOS Stream $releasever - AppStream
+baseurl=http://mirrors.aliyun.com/centos/$stream/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[extras-aliyun]
+name=Aliyun CentOS Stream $releasever - Extras
+baseurl=http://mirrors.aliyun.com/centos/$stream/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[powertools-aliyun]
+name=Aliyun CentOS Stream $releasever - PowerTools
+baseurl=http://mirrors.aliyun.com/centos/$stream/PowerTools/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+

--- a/build/centos-stream-8/pkg-builder/entrypoint.sh
+++ b/build/centos-stream-8/pkg-builder/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PACKAGE_ROOT="$PWD/build/centos-stream-8"
+
+if [[ ! -d "${PACKAGE_ROOT}/${INPUT_PACKAGE}" ]]; then
+    echo "Invalid package: ${INPUT_PACKAGE}"
+    exit 1
+fi
+
+cd "${PACKAGE_ROOT}/${INPUT_PACKAGE}" && ./build.sh


### PR DESCRIPTION
1. Add github action pkg-builder for CentOS Stream 8.
2. Use aliyun mirror for CentOS Stream's BaseOS, PowerTools and AppStream.
3. Enable github action to build testing for grub and shim.

Signed-off-by: Lu Ken <ken.lu@intel.com>