### PR TITLE
Add package build for TDVF(Trusted Domain Virtual Firmware) component

### DIFF
--- a/.github/workflows/pr-test-build-centos-stream-8.yml
+++ b/.github/workflows/pr-test-build-centos-stream-8.yml
@@ -18,3 +18,7 @@ jobs:
         uses: ./build/centos-stream-8/pkg-builder
         with:
           package: intel-mvp-tdx-guest-shim
+      - name: Build tdvf
+        uses: ./build/centos-stream-8/pkg-builder
+        with:
+          package: intel-mvp-tdx-tdvf

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,1 @@
+rpmbuild/

--- a/build/centos-stream-8/intel-mvp-tdx-tdvf/README.md
+++ b/build/centos-stream-8/intel-mvp-tdx-tdvf/README.md
@@ -1,0 +1,10 @@
+# Build TDVF (Trust Domain Virtual Firmware)
+
+This directory provides the build’s spec and script to generate TDVF RPMs.
+The downstream patches are held at https://github.com/tianocore/edk2-staging/tree/TDVF.
+
+The build based on CentOS-Stream 8 distro, so please setup build environment
+with CentOS Stream 8 in a development machine or container.
+
+_Reference:_
+- [TDVF Design Specification](https://www.intel.com/content/dam/develop/external/us/en/documents/tdx-virtual-firmware-design-guide-rev-1.pdf)

--- a/build/centos-stream-8/intel-mvp-tdx-tdvf/build.sh
+++ b/build/centos-stream-8/intel-mvp-tdx-tdvf/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+CURR_DIR=$(dirname "$(readlink -f "$0")")
+DOWNSTREAM_GIT_URI="https://github.com/tianocore/edk2-staging.git"
+DOWNSTREAM_TAG="2021-ww50.5"
+SPEC_FILE="${CURR_DIR}/tdvf.spec"
+RPMBUILD_DIR="${CURR_DIR}/rpmbuild"
+
+get_origin() {
+    echo "**** Download origin package ****"
+    if [[ ! -f ${CURR_DIR}/edk2.tar.gz ]]; then
+        git clone --single-branch --branch ${DOWNSTREAM_TAG} \
+            ${DOWNSTREAM_GIT_URI}
+        pushd edk2-staging
+	    git submodule set-url UnitTestFrameworkPkg/Library/CmockaLib/cmocka \
+            https://github.com/clibs/cmocka
+        git submodule init
+        git submodule sync
+        git submodule update
+        rm -rf .git/
+        popd
+        tar czf edk2.tar.gz edk2-staging/
+    fi
+}
+
+prepare() {
+    echo "**** Prepare ****"
+    cp "${CURR_DIR}/edk2.tar.gz" "${RPMBUILD_DIR}/SOURCES/"
+}
+
+build() {
+    echo "**** Build ****"
+    sudo -E dnf builddep -y "${SPEC_FILE}"
+    rpmbuild --define "_topdir ${RPMBUILD_DIR}" -v -ba "${SPEC_FILE}"
+}
+
+pushd "$CURR_DIR"
+mkdir -p "${RPMBUILD_DIR}"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+get_origin
+prepare
+build
+popd

--- a/build/centos-stream-8/intel-mvp-tdx-tdvf/tdvf.spec
+++ b/build/centos-stream-8/intel-mvp-tdx-tdvf/tdvf.spec
@@ -1,0 +1,90 @@
+%global debug_package %{nil}
+
+# This spec file began as CentOS's ovmf spec file, then cut down and modified.
+
+Name:       intel-mvp-tdx-tdvf
+Version:    2021.12.17
+Release:    ww50.5.mvp31
+Summary:    UEFI firmware for 64-bit virtual machines supporting trusted domains
+Group:      Applications/Emulators
+License:    BSD and OpenSSL and MIT
+URL:        http://www.tianocore.org
+
+Source0: edk2.tar.gz
+
+BuildRequires:  python2-devel
+BuildRequires:  libuuid-devel
+BuildRequires:  /usr/bin/iasl
+BuildRequires:  binutils gcc git
+
+# Only OVMF includes 80x86 assembly files (*.nasm*).
+BuildRequires:  nasm
+
+# Only OVMF includes the Secure Boot feature, for which we need to separate out
+# the UEFI shell.
+BuildRequires:  dosfstools
+BuildRequires:  mtools
+BuildRequires:  genisoimage
+
+# For generating the variable store template with the default certificates
+# enrolled, we need qemu-kvm (from base RHEL7) such that it includes basic OVMF
+# support (split pflash) -- see RHBZ#1032346.
+BuildRequires:  qemu-kvm >= 1.5.3-44
+
+# For verifying SB enablement in the above variable store template, we need a
+# trusted guest kernel that prints "Secure boot enabled". See RHBZ#903815.
+BuildRequires: kernel >= 3.10.0-52
+BuildRequires: rpmdevtools
+
+BuildArch:  noarch
+
+# OVMF includes the Secure Boot feature; it has a builtin OpenSSL library.
+Provides:   bundled(openssl) = 1.1.1g
+
+%description
+OVMF (Open Virtual Machine Firmware) is a project to enable UEFI support for
+Virtual Machines. This package contains a sample 64-bit UEFI firmware for QEMU
+and KVM supporting trusted domains.
+
+%prep
+%setup -q -n edk2-staging
+
+# Done by %setup, but we do not use it for the auxiliary tarballs
+chmod -Rf a+rX,u+w,g-w,o-w .
+
+%build
+export PYTHON_COMMAND=python3
+
+make -C BaseTools
+source ./edksetup.sh
+build -p OvmfPkg/OvmfPkgX64.dsc \
+      -a X64 -b DEBUG \
+      -t GCC5 \
+      -D DEBUG_ON_SERIAL_PORT=TRUE \
+      -D TDX_MEM_PARTIAL_ACCEPT=512 \
+      -D TDX_EMULATION_ENABLE=FALSE
+
+build -p OvmfPkg/OvmfPkgX64.dsc \
+      -a X64 -b RELEASE \
+      -t GCC5 \
+      -D DEBUG_ON_SERIAL_PORT=FALSE \
+      -D TDX_MEM_PARTIAL_ACCEPT=512 \
+      -D TDX_EMULATION_ENABLE=FALSE
+
+%install
+mkdir -p %{buildroot}/usr/share/qemu
+cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/OVMF.debug.fd
+cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/
+cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/OVMF_CODE.debug.fd
+cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/
+cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_VARS.fd %{buildroot}/usr/share/qemu/
+cp Build/OvmfX64/RELEASE_GCC*/X64/DumpTdxEventLog.efi %{buildroot}/usr/share/qemu/DumpTdxEventLog.efi
+
+%files
+%license License.txt
+/usr/share/qemu/OVMF.debug.fd
+/usr/share/qemu/OVMF.fd
+/usr/share/qemu/OVMF_CODE.debug.fd
+/usr/share/qemu/OVMF_CODE.fd
+/usr/share/qemu/OVMF_VARS.fd
+/usr/share/qemu/DumpTdxEventLog.efi


### PR DESCRIPTION
1. TDVF provide EFI BIOS for TD guest, it bases on OVMF.
2. TDVF spec https://software.intel.com/content/dam/develop/external/us/en/documents/tdx-virtual-firmware-design-guide-rev-1.pdf
3. Current implementation supports:
   - Lazy Page Accept
   - RTMR based measured boot
   - Secure boot
   - EFI handover approach for qemu direct and grub boot

Signed-off-by: Lu Ken <ken.lu@intel.com>