### PR TITLE
Add package build for TDX libvirt

### DIFF
--- a/.github/workflows/pr-test-build-centos-stream-8.yml
+++ b/.github/workflows/pr-test-build-centos-stream-8.yml
@@ -26,3 +26,7 @@ jobs:
         uses: ./build/centos-stream-8/pkg-builder
         with:
           package: intel-mvp-tdx-qemu-kvm
+      - name: Build libvirt
+        uses: ./build/centos-stream-8/pkg-builder
+        with:
+          package: intel-mvp-tdx-libvirt

--- a/build/centos-stream-8/intel-mvp-tdx-libvirt/README.md
+++ b/build/centos-stream-8/intel-mvp-tdx-libvirt/README.md
@@ -1,0 +1,9 @@
+# Build libvirt package for TDX host
+
+This directory provides the build’s spec and script to generate libvirt RPMs.
+The downstream patches are held at <https://github.com/intel/libvirt-tdx>.
+
+The build based on CentOS-Stream 8 distro:
+- The spec files comes from https://git.centos.org/rpms/libvirt/tree/c8s-stream-rhel
+- Please also setup build environment with CentOS Stream 8 in a development
+machine or container.

--- a/build/centos-stream-8/intel-mvp-tdx-libvirt/build.sh
+++ b/build/centos-stream-8/intel-mvp-tdx-libvirt/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+CURR_DIR=$(dirname "$(readlink -f "$0")")
+UPSTREAM_URI="https://libvirt.org/sources/libvirt-7.9.0.tar.xz"
+UPSTREAM_VERSION="7.9.0"
+UPSTREAM_BASE_COMMIT="750e2401955e422454d5fd5d94f2ba10e929fa8b"
+DOWNSTREAM_GIT_URI="https://github.com/intel/libvirt-tdx.git"
+DOWNSTREAM_TAG="tdx-libvirt-2021.12.08"
+UPTRREAM_FILE="${UPSTREAM_URI##*/}"
+DOWNSTREAM_VERSION=${DOWNSTREAM_TAG#tdx-libvirt-}
+PATCHES_TARBALL_NAME="patches-tdx-libvirt-${UPSTREAM_VERSION}-${DOWNSTREAM_VERSION}.tar.gz"
+SPEC_FILE="${CURR_DIR}/tdx-libvirt.spec"
+RPMBUILD_DIR="${CURR_DIR}/rpmbuild"
+
+get_origin() {
+    echo "**** Download origin package ****"
+    if [[ ! -f "${RPMBUILD_DIR}"/SOURCES/"${UPTRREAM_FILE}" ]]; then
+        wget -O "${UPTRREAM_FILE}" ${UPSTREAM_URI}
+        mv "${UPTRREAM_FILE}" "${RPMBUILD_DIR}"/SOURCES
+    fi
+}
+
+generate_patchset() {
+    echo "**** Create patchset ****"
+    if [[ ! -d libvirt ]]; then
+        git clone -b ${DOWNSTREAM_TAG} --single-branch ${DOWNSTREAM_GIT_URI} libvirt
+    fi
+    pushd libvirt
+    if [[ ! -f "${RPMBUILD_DIR}"/SOURCES/"${PATCHES_TARBALL_NAME}" ]]; then
+        git format-patch $UPSTREAM_BASE_COMMIT..$DOWNSTREAM_TAG
+        tar czf "${RPMBUILD_DIR}"/SOURCES/"${PATCHES_TARBALL_NAME}" ./*.patch
+    fi
+    popd
+}
+
+build() {
+    echo "**** Build ****"
+    sudo -E dnf builddep -y "${SPEC_FILE}"
+    rpmbuild --define "_topdir ${RPMBUILD_DIR}" -v -ba "${SPEC_FILE}"
+}
+
+pushd "${CURR_DIR}"
+mkdir -p "${RPMBUILD_DIR}"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+get_origin
+generate_patchset
+build
+popd

--- a/build/centos-stream-8/intel-mvp-tdx-libvirt/tdx-libvirt.spec
+++ b/build/centos-stream-8/intel-mvp-tdx-libvirt/tdx-libvirt.spec
@@ -1,0 +1,2235 @@
+# -*- rpm-spec -*-
+
+# This spec file assumes you are building on a Fedora or RHEL version
+# that's still supported by the vendor. It may work on other distros
+# or versions, but no effort will be made to ensure that going forward.
+%define min_rhel 8
+%define min_fedora 33
+
+%define arches_qemu_kvm         %{ix86} x86_64 %{power64} %{arm} aarch64 s390x
+%if 0%{?rhel}
+    %if 0%{?rhel} > 8
+        %define arches_qemu_kvm     x86_64 aarch64 s390x
+    %else
+        %define arches_qemu_kvm     x86_64 %{power64} aarch64 s390x
+    %endif
+%endif
+
+%define arches_64bit            x86_64 %{power64} aarch64 s390x riscv64
+%define arches_x86              %{ix86} x86_64
+
+%define arches_systemtap_64bit  %{arches_64bit}
+%define arches_dmidecode        %{arches_x86}
+%define arches_xen              %{arches_x86} aarch64
+%define arches_vbox             %{arches_x86}
+%define arches_ceph             %{arches_64bit}
+%define arches_zfs              %{arches_x86} %{power64} %{arm}
+%define arches_numactl          %{arches_x86} %{power64} aarch64 s390x
+%define arches_numad            %{arches_x86} %{power64} aarch64
+
+# The hypervisor drivers that run in libvirtd
+%define with_qemu          0%{!?_without_qemu:1}
+%define with_lxc           0%{!?_without_lxc:1}
+%define with_libxl         0%{!?_without_libxl:1}
+%define with_vbox          0%{!?_without_vbox:1}
+
+%ifarch %{arches_qemu_kvm}
+    %define with_qemu_kvm      %{with_qemu}
+%else
+    %define with_qemu_kvm      0
+%endif
+
+%define with_qemu_tcg      %{with_qemu}
+
+# RHEL disables TCG on all architectures
+%if 0%{?rhel}
+    %define with_qemu_tcg 0
+%endif
+
+%if ! %{with_qemu_tcg} && ! %{with_qemu_kvm}
+    %define with_qemu 0
+%endif
+
+# Then the hypervisor drivers that run outside libvirtd, in libvirt.so
+%define with_openvz        0%{!?_without_openvz:1}
+%define with_vmware        0%{!?_without_vmware:1}
+%define with_esx           0%{!?_without_esx:1}
+%define with_hyperv        0%{!?_without_hyperv:1}
+
+# Then the secondary host drivers, which run inside libvirtd
+%define with_storage_rbd      0%{!?_without_storage_rbd:1}
+%if 0%{?fedora}
+    %define with_storage_sheepdog 0%{!?_without_storage_sheepdog:1}
+%else
+    %define with_storage_sheepdog 0
+%endif
+
+%define with_storage_gluster 0%{!?_without_storage_gluster:1}
+%if 0%{?rhel}
+    # Glusterfs has been dropped in RHEL-9, and before that
+    # was only enabled on arches where KVM exists
+    %if 0%{?rhel} > 8
+        %define with_storage_gluster 0
+    %else
+        %ifnarch %{arches_qemu_kvm}
+            %define with_storage_gluster 0
+        %endif
+    %endif
+%endif
+
+# Fedora has zfs-fuse
+%if 0%{?fedora}
+    %define with_storage_zfs      0%{!?_without_storage_zfs:1}
+%else
+    %define with_storage_zfs      0
+%endif
+
+%define with_storage_iscsi_direct 0%{!?_without_storage_iscsi_direct:1}
+# libiscsi has been dropped in RHEL-9
+%if 0%{?rhel} > 8
+    %define with_storage_iscsi_direct 0
+%endif
+
+# Other optional features
+%define with_numactl          0%{!?_without_numactl:1}
+
+# A few optional bits off by default, we enable later
+%define with_fuse             0
+%define with_sanlock          0
+%define with_numad            0
+%define with_firewalld_zone   0
+%define with_netcf            0
+%define with_libssh2          0
+%define with_wireshark        0
+%define with_libssh           0
+%define with_dmidecode        0
+
+# Finally set the OS / architecture specific special cases
+
+# Architecture-dependent features
+%ifnarch %{arches_xen}
+    %define with_libxl 0
+%endif
+%ifnarch %{arches_vbox}
+    %define with_vbox 0
+%endif
+%ifnarch %{arches_numactl}
+    %define with_numactl 0
+%endif
+%ifnarch %{arches_zfs}
+    %define with_storage_zfs 0
+%endif
+%ifnarch %{arches_ceph}
+    %define with_storage_rbd 0
+%endif
+
+# RHEL doesn't ship many hypervisor drivers
+%if 0%{?rhel}
+    %define with_openvz 0
+    %define with_vbox 0
+    %define with_vmware 0
+    %define with_libxl 0
+    %define with_hyperv 0
+    %define with_vz 0
+    %define with_lxc 0
+%endif
+
+%define with_firewalld_zone 0%{!?_without_firewalld_zone:1}
+
+%if (0%{?fedora} && 0%{?fedora} < 34) || (0%{?rhel} && 0%{?rhel} < 9)
+    %define with_netcf 0%{!?_without_netcf:1}
+%endif
+
+
+# fuse is used to provide virtualized /proc for LXC
+%if %{with_lxc}
+    %define with_fuse      0%{!?_without_fuse:1}
+%endif
+
+# Enable sanlock library for lock management with QEMU
+# Sanlock is available only on arches where kvm is available for RHEL
+%if 0%{?fedora}
+    %define with_sanlock 0%{!?_without_sanlock:1}
+%endif
+%if 0%{?rhel}
+    %ifarch %{arches_qemu_kvm}
+        %define with_sanlock 0%{!?_without_sanlock:1}
+    %endif
+%endif
+
+# Enable libssh2 transport for new enough distros
+%if 0%{?fedora}
+    %define with_libssh2 0%{!?_without_libssh2:1}
+%endif
+
+# Enable wireshark plugins for all distros
+%define with_wireshark 0%{!?_without_wireshark:1}
+%define wireshark_plugindir %(pkg-config --variable plugindir wireshark)/epan
+
+# Enable libssh transport for all distros
+%define with_libssh 0%{!?_without_libssh:1}
+
+%if %{with_qemu} || %{with_lxc}
+# numad is used to manage the CPU and memory placement dynamically,
+# it's not available on many non-x86 architectures.
+    %ifarch %{arches_numad}
+        %define with_numad    0%{!?_without_numad:1}
+    %endif
+%endif
+
+%ifarch %{arches_dmidecode}
+    %define with_dmidecode 0%{!?_without_dmidecode:1}
+%endif
+
+%define with_modular_daemons 0
+%if 0%{?fedora} >= 35 || 0%{?rhel} >= 9
+    %define with_modular_daemons 1
+%endif
+
+# Force QEMU to run as non-root
+%define qemu_user  qemu
+%define qemu_group  qemu
+
+
+# RHEL releases provide stable tool chains and so it is safe to turn
+# compiler warning into errors without being worried about frequent
+# changes in reported warnings
+%if 0%{?rhel}
+    %define enable_werror -Dwerror=true
+%else
+    %define enable_werror -Dwerror=false -Dgit_werror=disabled
+%endif
+
+%define tls_priority "@LIBVIRT,SYSTEM"
+
+%define libvirt_daemon_schedule_restart() mkdir -p %{_localstatedir}/lib/rpm-state/libvirt || : \
+/bin/systemctl is-active %1.service 1>/dev/null 2>&1 && \
+  touch %{_localstatedir}/lib/rpm-state/libvirt/restart-%1 || :
+
+%define libvirt_daemon_finish_restart() rm -f %{_localstatedir}/lib/rpm-state/libvirt/restart-%1 \
+rmdir %{_localstatedir}/lib/rpm-state/libvirt 2>/dev/null || :
+
+%define libvirt_daemon_needs_restart() -f %{_localstatedir}/lib/rpm-state/libvirt/restart-%1
+
+%define libvirt_daemon_perform_restart() if test %libvirt_daemon_needs_restart %1 \
+then \
+  /bin/systemctl try-restart %1.service >/dev/null 2>&1 || : \
+fi \
+%libvirt_daemon_finish_restart %1
+
+%define libvirt_daemon_systemd_post() %systemd_post %1.socket %1-ro.socket %1-admin.socket %1.service
+
+%define libvirt_daemon_systemd_post_inet() %systemd_post %1.socket %1-ro.socket %1-admin.socket %1-tls.socket %1-tcp.socket %1.service
+
+%define libvirt_daemon_systemd_preun() %systemd_preun %1.service %1-ro.socket %1-admin.socket %1.socket
+
+%define libvirt_daemon_systemd_preun_inet() %systemd_preun %1.service %1-ro.socket %1-admin.socket %1-tls.socket %1-tcp.socket %1.socket
+
+Summary: Library providing a simple virtualization API
+Name: intel-mvp-tdx-libvirt
+Version: 7.9.0
+%define patch_number 10
+%define downstream_tag 2021.12.08
+Release: %{downstream_tag}.mvp%{patch_number}%{?dist}
+License: LGPLv2+
+URL: https://libvirt.org/
+
+Obsoletes: libvirt
+Provides: libvirt
+
+%if %(echo %{version} | grep -q "\.0$"; echo $?) == 1
+    %define mainturl stable_updates/
+%endif
+Source: https://libvirt.org/sources/%{?mainturl}libvirt-%{version}.tar.xz
+Source1: patches-tdx-libvirt-%{version}-%{downstream_tag}.tar.gz
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-config-network = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-config-nwfilter = %{version}-%{release}
+%if %{with_libxl}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-libxl = %{version}-%{release}
+%endif
+%if %{with_lxc}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-lxc = %{version}-%{release}
+%endif
+%if %{with_qemu}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-qemu = %{version}-%{release}
+%endif
+# We had UML driver, but we've removed it.
+Obsoletes: intel-mvp-tdx-libvirt-daemon-driver-uml <= 5.0.0
+Obsoletes: intel-mvp-tdx-libvirt-daemon-uml <= 5.0.0
+Obsoletes: libvirt-daemon-driver-uml <= 5.0.0
+Obsoletes: libvirt-daemon-uml <= 5.0.0
+%if %{with_vbox}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-vbox = %{version}-%{release}
+%endif
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nwfilter = %{version}-%{release}
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-interface = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-secret = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nodedev = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-client = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+
+# All build-time requirements. Run-time requirements are
+# listed against each sub-RPM
+BuildRequires: python3-docutils
+BuildRequires: gcc
+BuildRequires: meson >= 0.54.0
+BuildRequires: ninja-build
+BuildRequires: git
+BuildRequires: perl-interpreter
+BuildRequires: python3
+%if %{with_libxl}
+BuildRequires: xen-devel
+%endif
+BuildRequires: glib2-devel >= 2.56
+BuildRequires: libxml2-devel
+BuildRequires: libxslt
+BuildRequires: readline-devel
+BuildRequires: bash-completion >= 2.0
+BuildRequires: gettext
+BuildRequires: libtasn1-devel
+BuildRequires: gnutls-devel
+BuildRequires: libattr-devel
+# For pool-build probing for existing pools
+BuildRequires: libblkid-devel >= 2.17
+# for augparse, optionally used in testing
+BuildRequires: augeas
+BuildRequires: systemd-devel >= 185
+BuildRequires: libpciaccess-devel >= 0.10.9
+BuildRequires: yajl-devel
+%if %{with_sanlock}
+BuildRequires: sanlock-devel >= 2.4
+%endif
+BuildRequires: libpcap-devel >= 1.5.0
+BuildRequires: libnl3-devel
+BuildRequires: libselinux-devel
+BuildRequires: dnsmasq >= 2.41
+BuildRequires: iptables
+BuildRequires: radvd
+BuildRequires: ebtables
+BuildRequires: module-init-tools
+BuildRequires: cyrus-sasl-devel
+BuildRequires: polkit >= 0.112
+# For mount/umount in FS driver
+BuildRequires: util-linux
+%if %{with_qemu}
+# For managing ACLs
+BuildRequires: libacl-devel
+# From QEMU RPMs
+BuildRequires: /usr/bin/qemu-img
+%endif
+# For LVM drivers
+BuildRequires: lvm2
+# For pool type=iscsi
+BuildRequires: iscsi-initiator-utils
+%if %{with_storage_iscsi_direct}
+# For pool type=iscsi-direct
+BuildRequires: libiscsi-devel
+%endif
+# For disk driver
+BuildRequires: parted-devel
+# For Multipath support
+BuildRequires: device-mapper-devel
+# For XFS reflink clone support
+BuildRequires: xfsprogs-devel
+%if %{with_storage_rbd}
+BuildRequires: librados-devel
+BuildRequires: librbd-devel
+%endif
+%if %{with_storage_gluster}
+BuildRequires: glusterfs-api-devel >= 3.4.1
+BuildRequires: glusterfs-devel >= 3.4.1
+%endif
+%if %{with_storage_sheepdog}
+BuildRequires: sheepdog
+%endif
+%if %{with_storage_zfs}
+# Support any conforming implementation of zfs. On stock Fedora
+# this is zfs-fuse, but could be zfsonlinux upstream RPMs
+BuildRequires: /sbin/zfs
+BuildRequires: /sbin/zpool
+%endif
+%if %{with_numactl}
+# For QEMU/LXC numa info
+BuildRequires: numactl-devel
+%endif
+BuildRequires: libcap-ng-devel >= 0.5.0
+%if %{with_fuse}
+BuildRequires: fuse-devel >= 2.8.6
+%endif
+%if %{with_libssh2}
+BuildRequires: libssh2-devel >= 1.3.0
+%endif
+%if %{with_netcf}
+BuildRequires: netcf-devel >= 0.2.2
+%endif
+%if %{with_esx}
+BuildRequires: libcurl-devel
+%endif
+%if %{with_hyperv}
+BuildRequires: libwsman-devel >= 2.6.3
+%endif
+BuildRequires: audit-libs-devel
+# we need /usr/sbin/dtrace
+BuildRequires: systemtap-sdt-devel
+
+# For mount/umount in FS driver
+BuildRequires: util-linux
+# For showmount in FS driver (netfs discovery)
+BuildRequires: nfs-utils
+
+# Fedora build root suckage
+BuildRequires: gawk
+
+# For storage wiping with different algorithms
+BuildRequires: scrub
+
+%if %{with_numad}
+BuildRequires: numad
+%endif
+
+%if %{with_wireshark}
+BuildRequires: wireshark-devel
+%endif
+
+%if %{with_libssh}
+BuildRequires: libssh-devel >= 0.7.0
+%endif
+
+BuildRequires: rpcgen
+BuildRequires: libtirpc-devel
+
+# Needed for the firewalld_reload macro
+%if %{with_firewalld_zone}
+BuildRequires: firewalld-filesystem
+%endif
+
+%description
+Libvirt is a C toolkit to interact with the virtualization capabilities
+of recent versions of Linux (and other OSes). The main package includes
+the libvirtd server exporting the virtualization support.
+
+%package docs
+Summary: API reference and website documentation
+
+Obsoletes: libvirt-docs
+Provides: libvirt-docs
+
+%description docs
+Includes the API reference for the libvirt C library, and a complete
+copy of the libvirt.org website documentation.
+
+%package daemon
+Summary: Server side daemon and supporting files for libvirt library
+
+Obsoletes: libvirt-daemon
+Provides: libvirt-daemon
+
+# All runtime requirements for the libvirt package (runtime requrements
+# for subpackages are listed later in those subpackages)
+
+# The client side, i.e. shared libs are in a subpackage
+Requires: %{name}-libs = %{version}-%{release}
+
+# (client invokes 'nc' against the UNIX socket on the server)
+Requires: /usr/bin/nc
+
+# for modprobe of pci devices
+Requires: module-init-tools
+
+# for /sbin/ip
+Requires: iproute
+# for /sbin/tc
+Requires: iproute-tc
+
+Requires: polkit >= 0.112
+%if %{with_dmidecode}
+# For virConnectGetSysinfo
+Requires: dmidecode
+%endif
+# For service management
+Requires(post): /usr/bin/systemctl
+%if %{with_numad}
+Requires: numad
+%endif
+# libvirtd depends on 'messagebus' service
+Requires: dbus
+# For uid creation during pre
+Requires(pre): shadow-utils
+# Needed by /usr/libexec/libvirt-guests.sh script.
+Requires: gettext
+
+# Ensure smooth upgrades
+Obsoletes: intel-mvp-tdx-libvirt-admin < 7.3.0
+Provides: intel-mvp-tdx-libvirt-admin = %{version}-%{release}
+Obsoletes: intel-mvp-tdx-libvirt-bash-completion < 7.3.0
+
+%description daemon
+Server side daemon required to manage the virtualization capabilities
+of recent versions of Linux. Requires a hypervisor specific sub-RPM
+for specific drivers.
+
+%package daemon-config-network
+Summary: Default configuration files for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-config-network
+Provides: libvirt-daemon-config-network
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+
+%description daemon-config-network
+Default configuration files for setting up NAT based networking
+
+%package daemon-config-nwfilter
+Summary: Network filter configuration files for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-config-nwfilter
+Provides: libvirt-daemon-config-nwfilter
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nwfilter = %{version}-%{release}
+
+%description daemon-config-nwfilter
+Network filter configuration files for cleaning guest traffic
+
+%package daemon-driver-network
+Summary: Network driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-network
+Provides: libvirt-daemon-driver-network
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: dnsmasq >= 2.41
+Requires: radvd
+Requires: iptables
+
+%description daemon-driver-network
+The network driver plugin for the libvirtd daemon, providing
+an implementation of the virtual network APIs using the Linux
+bridge capabilities.
+
+
+%package daemon-driver-nwfilter
+Summary: Nwfilter driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-nwfilter
+Provides: libvirt-daemon-driver-nwfilter
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: iptables
+Requires: ebtables
+
+%description daemon-driver-nwfilter
+The nwfilter driver plugin for the libvirtd daemon, providing
+an implementation of the firewall APIs using the ebtables,
+iptables and ip6tables capabilities
+
+
+%package daemon-driver-nodedev
+Summary: Nodedev driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-nodedev
+Provides: libvirt-daemon-driver-nodedev
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+# needed for device enumeration
+Requires: systemd >= 185
+# For managing persistent mediated devices
+Requires: mdevctl
+
+%description daemon-driver-nodedev
+The nodedev driver plugin for the libvirtd daemon, providing
+an implementation of the node device APIs using the udev
+capabilities.
+
+
+%package daemon-driver-interface
+Summary: Interface driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-interface
+Provides: libvirt-daemon-driver-interface
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+%if %{with_netcf}
+Requires: netcf-libs >= 0.2.2
+%endif
+
+%description daemon-driver-interface
+The interface driver plugin for the libvirtd daemon, providing
+an implementation of the host network interface APIs.
+
+%package daemon-driver-secret
+Summary: Secret driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-secret
+Provides: libvirt-daemon-driver-secret
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+
+%description daemon-driver-secret
+The secret driver plugin for the libvirtd daemon, providing
+an implementation of the secret key APIs.
+
+%package daemon-driver-storage-core
+Summary: Storage driver plugin including base backends for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-storage-core
+Provides: libvirt-daemon-driver-storage-core
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: nfs-utils
+# For mkfs
+Requires: util-linux
+%if %{with_qemu}
+# From QEMU RPMs
+Requires: /usr/bin/qemu-img
+%endif
+%if !%{with_storage_rbd}
+Obsoletes: intel-mvp-tdx-libvirt-daemon-driver-storage-rbd < %{version}-%{release}
+%endif
+
+%description daemon-driver-storage-core
+The storage driver plugin for the libvirtd daemon, providing
+an implementation of the storage APIs using files, local disks, LVM, SCSI,
+iSCSI, and multipath storage.
+
+%package daemon-driver-storage-logical
+Summary: Storage driver plugin for lvm volumes
+
+Obsoletes: libvirt-daemon-driver-storage-logical
+Provides: libvirt-daemon-driver-storage-logical
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: lvm2
+
+%description daemon-driver-storage-logical
+The storage driver backend adding implementation of the storage APIs for block
+volumes using lvm.
+
+
+%package daemon-driver-storage-disk
+Summary: Storage driver plugin for disk
+
+Obsoletes: libvirt-daemon-driver-storage-disk
+Provides: libvirt-daemon-driver-storage-disk
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: parted
+Requires: device-mapper
+
+%description daemon-driver-storage-disk
+The storage driver backend adding implementation of the storage APIs for block
+volumes using the host disks.
+
+
+%package daemon-driver-storage-scsi
+Summary: Storage driver plugin for local scsi devices
+
+Obsoletes: libvirt-daemon-driver-storage-scsi
+Provides: libvirt-daemon-driver-storage-scsi
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+
+%description daemon-driver-storage-scsi
+The storage driver backend adding implementation of the storage APIs for scsi
+host devices.
+
+
+%package daemon-driver-storage-iscsi
+Summary: Storage driver plugin for iscsi
+
+Obsoletes: libvirt-daemon-driver-storage-iscsi
+Provides: libvirt-daemon-driver-storage-iscsi
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: iscsi-initiator-utils
+
+%description daemon-driver-storage-iscsi
+The storage driver backend adding implementation of the storage APIs for iscsi
+volumes using the host iscsi stack.
+
+
+%if %{with_storage_iscsi_direct}
+%package daemon-driver-storage-iscsi-direct
+Summary: Storage driver plugin for iscsi-direct
+
+Obsoletes: libvirt-daemon-driver-storage-iscsi-direct
+Provides: libvirt-daemon-driver-storage-iscsi-direct
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+
+%description daemon-driver-storage-iscsi-direct
+The storage driver backend adding implementation of the storage APIs for iscsi
+volumes using libiscsi direct connection.
+%endif
+
+
+%package daemon-driver-storage-mpath
+Summary: Storage driver plugin for multipath volumes
+
+Obsoletes: libvirt-daemon-driver-storage-mpath
+Provides: libvirt-daemon-driver-storage-mpath
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: device-mapper
+
+%description daemon-driver-storage-mpath
+The storage driver backend adding implementation of the storage APIs for
+multipath storage using device mapper.
+
+
+%if %{with_storage_gluster}
+%package daemon-driver-storage-gluster
+Summary: Storage driver plugin for gluster
+
+Obsoletes: libvirt-daemon-driver-storage-gluster
+Provides: libvirt-daemon-driver-storage-gluster
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+    %if 0%{?fedora}
+Requires: glusterfs-client >= 2.0.1
+    %endif
+    %if (0%{?fedora} || 0%{?with_storage_gluster})
+Requires: /usr/sbin/gluster
+    %endif
+
+%description daemon-driver-storage-gluster
+The storage driver backend adding implementation of the storage APIs for gluster
+volumes using libgfapi.
+%endif
+
+
+%if %{with_storage_rbd}
+%package daemon-driver-storage-rbd
+Summary: Storage driver plugin for rbd
+
+Obsoletes: libvirt-daemon-driver-storage-rbd
+Provides: libvirt-daemon-driver-storage-rbd
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+
+%description daemon-driver-storage-rbd
+The storage driver backend adding implementation of the storage APIs for rbd
+volumes using the ceph protocol.
+%endif
+
+
+%if %{with_storage_sheepdog}
+%package daemon-driver-storage-sheepdog
+Summary: Storage driver plugin for sheepdog
+
+Obsoletes: libvirt-daemon-driver-storage-sheepdog
+Provides: libvirt-daemon-driver-storage-sheepdog
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: sheepdog
+
+%description daemon-driver-storage-sheepdog
+The storage driver backend adding implementation of the storage APIs for
+sheepdog volumes using.
+%endif
+
+
+%if %{with_storage_zfs}
+%package daemon-driver-storage-zfs
+Summary: Storage driver plugin for ZFS
+
+Obsoletes: libvirt-daemon-driver-storage-zfs
+Provides: libvirt-daemon-driver-storage-zfs
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+# Support any conforming implementation of zfs
+Requires: /sbin/zfs
+Requires: /sbin/zpool
+
+%description daemon-driver-storage-zfs
+The storage driver backend adding implementation of the storage APIs for
+ZFS volumes.
+%endif
+
+
+%package daemon-driver-storage
+Summary: Storage driver plugin including all backends for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-storage
+Provides: libvirt-daemon-driver-storage
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-core = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-disk = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-logical = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-scsi = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-iscsi = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-mpath = %{version}-%{release}
+%if %{with_storage_iscsi_direct}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-iscsi-direct = %{version}-%{release}
+%endif
+%if %{with_storage_gluster}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-gluster = %{version}-%{release}
+%endif
+%if %{with_storage_rbd}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-rbd = %{version}-%{release}
+%endif
+%if %{with_storage_sheepdog}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-sheepdog = %{version}-%{release}
+%endif
+%if %{with_storage_zfs}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage-zfs = %{version}-%{release}
+%endif
+
+%description daemon-driver-storage
+The storage driver plugin for the libvirtd daemon, providing
+an implementation of the storage APIs using LVM, iSCSI,
+parted and more.
+
+
+%if %{with_qemu}
+%package daemon-driver-qemu
+Summary: QEMU driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-qemu
+Provides: libvirt-daemon-driver-qemu
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Requires: /usr/bin/qemu-img
+# For image compression
+Requires: gzip
+Requires: bzip2
+Requires: lzop
+Requires: xz
+Requires: systemd-container
+Requires: swtpm-tools
+
+%description daemon-driver-qemu
+The qemu driver plugin for the libvirtd daemon, providing
+an implementation of the hypervisor driver APIs using
+QEMU
+%endif
+
+
+%if %{with_lxc}
+%package daemon-driver-lxc
+Summary: LXC driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-lxc
+Provides: libvirt-daemon-driver-lxc
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+# There really is a hard cross-driver dependency here
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+Requires: systemd-container
+
+%description daemon-driver-lxc
+The LXC driver plugin for the libvirtd daemon, providing
+an implementation of the hypervisor driver APIs using
+the Linux kernel
+%endif
+
+
+%if %{with_vbox}
+%package daemon-driver-vbox
+Summary: VirtualBox driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-vbox
+Provides: libvirt-daemon-driver-vbox
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+
+%description daemon-driver-vbox
+The vbox driver plugin for the libvirtd daemon, providing
+an implementation of the hypervisor driver APIs using
+VirtualBox
+%endif
+
+
+%if %{with_libxl}
+%package daemon-driver-libxl
+Summary: Libxl driver plugin for the libvirtd daemon
+
+Obsoletes: libvirt-daemon-driver-libxl
+Provides: libvirt-daemon-driver-libxl
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-libs = %{version}-%{release}
+Obsoletes: intel-mvp-tdx-libvirt-daemon-driver-xen < 4.3.0
+Obsoletes: libvirt-daemon-driver-xen < 4.3.0
+
+%description daemon-driver-libxl
+The Libxl driver plugin for the libvirtd daemon, providing
+an implementation of the hypervisor driver APIs using
+Libxl
+%endif
+
+
+
+%if %{with_qemu_tcg}
+%package daemon-qemu
+
+Obsoletes: libvirt-daemon-qemu
+Provides: libvirt-daemon-qemu
+
+Summary: Server side daemon & driver required to run QEMU guests
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-qemu = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-interface = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nodedev = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nwfilter = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-secret = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage = %{version}-%{release}
+Requires: intel-mvp-tdx-qemu
+
+%description daemon-qemu
+Server side daemon and driver required to manage the virtualization
+capabilities of the QEMU TCG emulators
+%endif
+
+
+%if %{with_qemu_kvm}
+%package daemon-kvm
+Summary: Server side daemon & driver required to run KVM guests
+
+Obsoletes: libvirt-daemon-kvm
+Provides: libvirt-daemon-kvm
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-qemu = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-interface = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nodedev = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nwfilter = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-secret = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage = %{version}-%{release}
+Requires: intel-mvp-tdx-qemu-kvm
+
+%description daemon-kvm
+Server side daemon and driver required to manage the virtualization
+capabilities of the KVM hypervisor
+%endif
+
+
+%if %{with_lxc}
+%package daemon-lxc
+Summary: Server side daemon & driver required to run LXC guests
+
+Obsoletes: libvirt-daemon-lxc
+Provides: libvirt-daemon-lxc
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-lxc = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-interface = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nodedev = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nwfilter = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-secret = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage = %{version}-%{release}
+
+%description daemon-lxc
+Server side daemon and driver required to manage the virtualization
+capabilities of LXC
+%endif
+
+
+%if %{with_libxl}
+%package daemon-xen
+Summary: Server side daemon & driver required to run XEN guests
+
+Obsoletes: libvirt-daemon-xen
+Provides: libvirt-daemon-xen
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+    %if %{with_libxl}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-libxl = %{version}-%{release}
+    %endif
+Requires: intel-mvp-tdx-libvirt-daemon-driver-interface = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nodedev = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nwfilter = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-secret = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage = %{version}-%{release}
+Requires: xen
+
+%description daemon-xen
+Server side daemon and driver required to manage the virtualization
+capabilities of XEN
+%endif
+
+%if %{with_vbox}
+%package daemon-vbox
+Summary: Server side daemon & driver required to run VirtualBox guests
+
+Obsoletes: libvirt-daemon-vbox
+Provides: libvirt-daemon-vbox
+
+Requires: intel-mvp-tdx-libvirt-daemon = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-vbox = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-interface = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nodedev = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-nwfilter = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-secret = %{version}-%{release}
+Requires: intel-mvp-tdx-libvirt-daemon-driver-storage = %{version}-%{release}
+
+%description daemon-vbox
+Server side daemon and driver required to manage the virtualization
+capabilities of VirtualBox
+%endif
+
+%package client
+Summary: Client side utilities of the libvirt library
+
+Obsoletes: libvirt-client
+Provides: libvirt-client
+
+Requires: %{name}-libs = %{version}-%{release}
+# Needed by virt-pki-validate script.
+Requires: gnutls-utils
+
+# Ensure smooth upgrades
+Obsoletes: intel-mvp-tdx-libvirt-bash-completion < 7.3.0
+
+%description client
+The client binaries needed to access the virtualization
+capabilities of recent versions of Linux (and other OSes).
+
+%package libs
+Summary: Client side libraries
+
+Obsoletes: libvirt-libs
+Provides: libvirt-libs
+
+# So remote clients can access libvirt over SSH tunnel
+Requires: cyrus-sasl
+# Needed by default sasl.conf - no onerous extra deps, since
+# 100's of other things on a system already pull in krb5-libs
+Requires: cyrus-sasl-gssapi
+
+%description libs
+Shared libraries for accessing the libvirt daemon.
+
+%if %{with_wireshark}
+%package wireshark
+Summary: Wireshark dissector plugin for libvirt RPC transactions
+
+Obsoletes: libvirt-wireshark
+Provides: libvirt-wireshark
+
+Requires: wireshark
+Requires: %{name}-libs = %{version}-%{release}
+
+%description wireshark
+Wireshark dissector plugin for better analysis of libvirt RPC traffic.
+%endif
+
+%if %{with_lxc}
+%package login-shell
+Summary: Login shell for connecting users to an LXC container
+Requires: %{name}-libs = %{version}-%{release}
+
+Obsoletes: libvirt-login-shell
+Provides: libvirt-login-shell
+
+%description login-shell
+Provides the set-uid virt-login-shell binary that is used to
+connect a user to an LXC container when they login, by switching
+namespaces.
+%endif
+
+%package devel
+Summary: Libraries, includes, etc. to compile with the libvirt library
+Requires: %{name}-libs = %{version}-%{release}
+Requires: pkgconfig
+
+Obsoletes: libvirt-devel
+Provides: libvirt-devel
+
+%description devel
+Include header files & development libraries for the libvirt C library.
+
+%if %{with_sanlock}
+%package lock-sanlock
+Summary: Sanlock lock manager plugin for QEMU driver
+
+Obsoletes: libvirt-lock-sanlock
+Provides: libvirt-lock-sanlock
+
+Requires: sanlock >= 2.4
+#for virt-sanlock-cleanup require augeas
+Requires: augeas
+Requires: %{name}-daemon = %{version}-%{release}
+Requires: %{name}-libs = %{version}-%{release}
+
+%description lock-sanlock
+Includes the Sanlock lock manager plugin for the QEMU
+driver
+%endif
+
+%package nss
+Summary: Libvirt plugin for Name Service Switch
+
+Obsoletes: libvirt-nss
+Provides: libvirt-nss
+
+Requires: intel-mvp-tdx-libvirt-daemon-driver-network = %{version}-%{release}
+
+%description nss
+Libvirt plugin for NSS for translating domain names into IP addresses.
+
+
+%prep
+
+ExtractPatches()
+{
+    local patchtarball=$1
+
+    if [ ! -f $patchtarball ]; then
+        echo "ExtractPatches"
+        exit 1
+    fi
+    tar xf $patchtarball
+}
+ExtractPatches %{SOURCE1}
+
+%autosetup -S git_am -n libvirt-%{version}
+
+for p in ../*.patch; do
+     patch -p1 -F1 -s < $p
+done
+
+
+%build
+%if 0%{?fedora} >= %{min_fedora} || 0%{?rhel} >= %{min_rhel}
+    %define supported_platform 1
+%else
+    %define supported_platform 0
+%endif
+
+%if ! %{supported_platform}
+echo "This RPM requires either Fedora >= %{min_fedora} or RHEL >= %{min_rhel}"
+exit 1
+%endif
+
+%if %{with_qemu}
+    %define arg_qemu -Ddriver_qemu=enabled
+%else
+    %define arg_qemu -Ddriver_qemu=disabled
+%endif
+
+%if %{with_openvz}
+    %define arg_openvz -Ddriver_openvz=enabled
+%else
+    %define arg_openvz -Ddriver_openvz=disabled
+%endif
+
+%if %{with_lxc}
+    %define arg_lxc -Ddriver_lxc=enabled
+    %define arg_login_shell -Dlogin_shell=enabled
+%else
+    %define arg_lxc -Ddriver_lxc=disabled
+    %define arg_login_shell -Dlogin_shell=disabled
+%endif
+
+%if %{with_vbox}
+    %define arg_vbox -Ddriver_vbox=enabled
+%else
+    %define arg_vbox -Ddriver_vbox=disabled
+%endif
+
+%if %{with_libxl}
+    %define arg_libxl -Ddriver_libxl=enabled
+%else
+    %define arg_libxl -Ddriver_libxl=disabled
+%endif
+
+%if %{with_esx}
+    %define arg_esx -Ddriver_esx=enabled -Dcurl=enabled
+%else
+    %define arg_esx -Ddriver_esx=disabled -Dcurl=disabled
+%endif
+
+%if %{with_hyperv}
+    %define arg_hyperv -Ddriver_hyperv=enabled -Dopenwsman=enabled
+%else
+    %define arg_hyperv -Ddriver_hyperv=disabled -Dopenwsman=disabled
+%endif
+
+%if %{with_vmware}
+    %define arg_vmware -Ddriver_vmware=enabled
+%else
+    %define arg_vmware -Ddriver_vmware=disabled
+%endif
+
+%if %{with_storage_rbd}
+    %define arg_storage_rbd -Dstorage_rbd=enabled
+%else
+    %define arg_storage_rbd -Dstorage_rbd=disabled
+%endif
+
+%if %{with_storage_sheepdog}
+    %define arg_storage_sheepdog -Dstorage_sheepdog=enabled
+%else
+    %define arg_storage_sheepdog -Dstorage_sheepdog=disabled
+%endif
+
+%if %{with_storage_gluster}
+    %define arg_storage_gluster -Dstorage_gluster=enabled -Dglusterfs=enabled
+%else
+    %define arg_storage_gluster -Dstorage_gluster=disabled -Dglusterfs=disabled
+%endif
+
+%if %{with_storage_zfs}
+    %define arg_storage_zfs -Dstorage_zfs=enabled
+%else
+    %define arg_storage_zfs -Dstorage_zfs=disabled
+%endif
+
+%if %{with_numactl}
+    %define arg_numactl -Dnumactl=enabled
+%else
+    %define arg_numactl -Dnumactl=disabled
+%endif
+
+%if %{with_numad}
+    %define arg_numad -Dnumad=enabled
+%else
+    %define arg_numad -Dnumad=disabled
+%endif
+
+%if %{with_fuse}
+    %define arg_fuse -Dfuse=enabled
+%else
+    %define arg_fuse -Dfuse=disabled
+%endif
+
+%if %{with_sanlock}
+    %define arg_sanlock -Dsanlock=enabled
+%else
+    %define arg_sanlock -Dsanlock=disabled
+%endif
+
+%if %{with_firewalld_zone}
+    %define arg_firewalld_zone -Dfirewalld_zone=enabled
+%else
+    %define arg_firewalld_zone -Dfirewalld_zone=disabled
+%endif
+
+%if %{with_netcf}
+    %define arg_netcf -Dnetcf=enabled
+%else
+    %define arg_netcf -Dnetcf=disabled
+%endif
+
+%if %{with_wireshark}
+    %define arg_wireshark -Dwireshark_dissector=enabled
+%else
+    %define arg_wireshark -Dwireshark_dissector=disabled
+%endif
+
+%if %{with_storage_iscsi_direct}
+    %define arg_storage_iscsi_direct -Dstorage_iscsi_direct=enabled -Dlibiscsi=enabled
+%else
+    %define arg_storage_iscsi_direct -Dstorage_iscsi_direct=disabled -Dlibiscsi=disabled
+%endif
+
+%if %{with_libssh}
+    %define arg_libssh -Dlibssh=enabled
+%else
+    %define arg_libssh -Dlibssh=disabled
+%endif
+
+%if %{with_libssh2}
+    %define arg_libssh2 -Dlibssh2=enabled
+%else
+    %define arg_libssh2 -Dlibssh2=disabled
+%endif
+
+%if %{with_modular_daemons}
+    %define arg_remote_mode -Dremote_default_mode=direct
+%else
+    %define arg_remote_mode -Dremote_default_mode=legacy
+%endif
+
+%define when  %(date +"%%F-%%T")
+%define where %(hostname)
+%define who   %{?packager}%{!?packager:Unknown}
+%define arg_packager -Dpackager="%{who}, %{when}, %{where}"
+%define arg_packager_version -Dpackager_version="%{release}"
+
+%define arg_selinux_mount -Dselinux_mount="/sys/fs/selinux"
+
+# place macros above and build commands below this comment
+
+export SOURCE_DATE_EPOCH=$(stat --printf='%Y' %{_specdir}/%{name}.spec)
+
+%meson \
+           -Drunstatedir=%{_rundir} \
+           %{?arg_qemu} \
+           %{?arg_openvz} \
+           %{?arg_lxc} \
+           %{?arg_vbox} \
+           %{?arg_libxl} \
+           -Dsasl=enabled \
+           -Dpolkit=enabled \
+           -Ddriver_libvirtd=enabled \
+           -Ddriver_remote=enabled \
+           -Ddriver_test=enabled \
+           %{?arg_esx} \
+           %{?arg_hyperv} \
+           %{?arg_vmware} \
+           -Ddriver_vz=disabled \
+           -Ddriver_bhyve=disabled \
+           -Ddriver_ch=disabled \
+           %{?arg_remote_mode} \
+           -Ddriver_interface=enabled \
+           -Ddriver_network=enabled \
+           -Dstorage_fs=enabled \
+           -Dstorage_lvm=enabled \
+           -Dstorage_iscsi=enabled \
+           %{?arg_storage_iscsi_direct} \
+           -Dstorage_scsi=enabled \
+           -Dstorage_disk=enabled \
+           -Dstorage_mpath=enabled \
+           %{?arg_storage_rbd} \
+           %{?arg_storage_sheepdog} \
+           %{?arg_storage_gluster} \
+           %{?arg_storage_zfs} \
+           -Dstorage_vstorage=disabled \
+           %{?arg_numactl} \
+           %{?arg_numad} \
+           -Dcapng=enabled \
+           %{?arg_fuse} \
+           %{?arg_netcf} \
+           -Dselinux=enabled \
+           %{?arg_selinux_mount} \
+           -Dapparmor=disabled \
+           -Dapparmor_profiles=disabled \
+           -Dsecdriver_apparmor=disabled \
+           -Dudev=enabled \
+           -Dyajl=enabled \
+           %{?arg_sanlock} \
+           -Dlibpcap=enabled \
+           -Dlibnl=enabled \
+           -Daudit=enabled \
+           -Ddtrace=enabled \
+           -Dfirewalld=enabled \
+           %{?arg_firewalld_zone} \
+           %{?arg_wireshark} \
+           %{?arg_libssh} \
+           %{?arg_libssh2} \
+           -Dpm_utils=disabled \
+           -Dnss=enabled \
+           %{arg_packager} \
+           %{arg_packager_version} \
+           -Dqemu_user=%{qemu_user} \
+           -Dqemu_group=%{qemu_group} \
+           -Dtls_priority=%{tls_priority} \
+           %{?enable_werror} \
+           -Dexpensive_tests=enabled \
+           -Dinit_script=systemd \
+           -Ddocs=enabled \
+           -Dtests=enabled \
+           -Drpath=disabled \
+           %{?arg_login_shell}
+
+%meson_build
+
+%install
+rm -fr %{buildroot}
+
+export SOURCE_DATE_EPOCH=$(stat --printf='%Y' %{_specdir}/%{name}.spec)
+
+%meson_install
+
+rm -f $RPM_BUILD_ROOT%{_libdir}/*.la
+rm -f $RPM_BUILD_ROOT%{_libdir}/*.a
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/lock-driver/*.la
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/lock-driver/*.a
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/connection-driver/*.la
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/connection-driver/*.a
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/storage-backend/*.la
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/storage-backend/*.a
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/storage-file/*.la
+rm -f $RPM_BUILD_ROOT%{_libdir}/libvirt/storage-file/*.a
+%if %{with_wireshark}
+rm -f $RPM_BUILD_ROOT%{wireshark_plugindir}/libvirt.la
+%endif
+
+install -d -m 0755 $RPM_BUILD_ROOT%{_datadir}/lib/libvirt/dnsmasq/
+# We don't want to install /etc/libvirt/qemu/networks in the main %%files list
+# because if the admin wants to delete the default network completely, we don't
+# want to end up re-incarnating it on every RPM upgrade.
+install -d -m 0755 $RPM_BUILD_ROOT%{_datadir}/libvirt/networks/
+cp $RPM_BUILD_ROOT%{_sysconfdir}/libvirt/qemu/networks/default.xml \
+   $RPM_BUILD_ROOT%{_datadir}/libvirt/networks/default.xml
+# libvirt saves this file with mode 0600
+chmod 0600 $RPM_BUILD_ROOT%{_sysconfdir}/libvirt/qemu/networks/default.xml
+
+# nwfilter files are installed in /usr/share/libvirt and copied to /etc in %%post
+# to avoid verification errors on changed files in /etc
+install -d -m 0755 $RPM_BUILD_ROOT%{_datadir}/libvirt/nwfilter/
+cp -a $RPM_BUILD_ROOT%{_sysconfdir}/libvirt/nwfilter/*.xml \
+    $RPM_BUILD_ROOT%{_datadir}/libvirt/nwfilter/
+# libvirt saves these files with mode 600
+chmod 600 $RPM_BUILD_ROOT%{_sysconfdir}/libvirt/nwfilter/*.xml
+
+%if ! %{with_qemu}
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/libvirtd_qemu.aug
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/tests/test_libvirtd_qemu.aug
+%endif
+%find_lang libvirt
+
+%if ! %{with_sanlock}
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/libvirt_sanlock.aug
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/tests/test_libvirt_sanlock.aug
+%endif
+
+%if ! %{with_lxc}
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/libvirtd_lxc.aug
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/tests/test_libvirtd_lxc.aug
+%endif
+
+%if ! %{with_qemu}
+rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/libvirt/qemu.conf
+rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/libvirtd.qemu
+%endif
+%if ! %{with_lxc}
+rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/libvirt/lxc.conf
+rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/libvirtd.lxc
+%endif
+%if ! %{with_libxl}
+rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/libvirt/libxl.conf
+rm -rf $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/libvirtd.libxl
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/libvirtd_libxl.aug
+rm -f $RPM_BUILD_ROOT%{_datadir}/augeas/lenses/tests/test_libvirtd_libxl.aug
+%endif
+
+# Copied into libvirt-docs subpackage eventually
+mv $RPM_BUILD_ROOT%{_datadir}/doc/libvirt libvirt-docs
+
+%ifarch %{arches_systemtap_64bit}
+mv $RPM_BUILD_ROOT%{_datadir}/systemtap/tapset/libvirt_probes.stp \
+   $RPM_BUILD_ROOT%{_datadir}/systemtap/tapset/libvirt_probes-64.stp
+
+    %if %{with_qemu}
+mv $RPM_BUILD_ROOT%{_datadir}/systemtap/tapset/libvirt_qemu_probes.stp \
+   $RPM_BUILD_ROOT%{_datadir}/systemtap/tapset/libvirt_qemu_probes-64.stp
+    %endif
+%endif
+
+%check
+# These tests don't current work in a mock build root
+cd tests
+for i in commandtest eventtest
+do
+   rm -f $i
+   printf 'int main(void) { return 0; }' > $i.c
+   printf '#!/bin/sh\nexit 0\n' > $i
+   chmod +x $i
+done
+cd ..
+
+
+# Building on slow archs, like emulated s390x in Fedora copr, requires
+# raising the test timeout
+VIR_TEST_DEBUG=1 %meson_test --no-suite syntax-check --timeout-multiplier 10
+
+%pre daemon
+# 'libvirt' group is just to allow password-less polkit access to
+# libvirtd. The uid number is irrelevant, so we use dynamic allocation
+# described at the above link.
+getent group libvirt >/dev/null || groupadd -r libvirt
+
+exit 0
+
+%post daemon
+%libvirt_daemon_systemd_post virtlogd
+%libvirt_daemon_systemd_post virtlockdd
+%if %{with_modular_daemons}
+%libvirt_daemon_systemd_post_inet virtproxyd
+%else
+%libvirt_daemon_systemd_post_inet libvirtd
+%endif
+
+%systemd_post libvirt-guests.service
+
+%libvirt_daemon_schedule_restart libvirtd
+
+%preun daemon
+%systemd_preun libvirt-guests.service
+
+%libvirt_daemon_systemd_preun_inet libvirtd
+%libvirt_daemon_systemd_preun_inet virtproxyd
+%libvirt_daemon_systemd_preun virtlogd
+%libvirt_daemon_systemd_preun virtlockdd
+
+%postun daemon
+/bin/systemctl daemon-reload >/dev/null 2>&1 || :
+if [ $1 -ge 1 ] ; then
+    /bin/systemctl reload-or-try-restart virtlockd.service virtlogd.service >/dev/null 2>&1 || :
+fi
+%systemd_postun libvirt-guests.service
+
+# In upgrade scenario we must explicitly enable virtlockd/virtlogd
+# sockets, if libvirtd is already enabled and start them if
+# libvirtd is running, otherwise you'll get failures to start
+# guests
+%triggerpostun daemon -- libvirt-daemon < 1.3.0
+if [ $1 -ge 1 ] ; then
+    /bin/systemctl is-enabled libvirtd.service 1>/dev/null 2>&1 &&
+        /bin/systemctl enable virtlogd.socket virtlogd-admin.socket || :
+    /bin/systemctl is-active libvirtd.service 1>/dev/null 2>&1 &&
+        /bin/systemctl start virtlogd.socket virtlogd-admin.socket || :
+fi
+
+%posttrans daemon
+if test %libvirt_daemon_needs_restart libvirtd
+then
+    # See if user has previously modified their install to
+    # tell libvirtd to use --listen
+    grep -E '^LIBVIRTD_ARGS=.*--listen' /etc/sysconfig/libvirtd 1>/dev/null 2>&1
+    if test $? = 0
+    then
+        # Then lets keep honouring --listen and *not* use
+        # systemd socket activation, because switching things
+        # might confuse mgmt tool like puppet/ansible that
+        # expect the old style libvirtd
+        /bin/systemctl mask \
+                libvirtd.socket \
+                libvirtd-ro.socket \
+                libvirtd-admin.socket \
+                libvirtd-tls.socket \
+                libvirtd-tcp.socket >/dev/null 2>&1 || :
+    else
+        # Old libvirtd owns the sockets and will delete them on
+        # shutdown. Can't use a try-restart as libvirtd will simply
+        # own the sockets again when it comes back up. Thus we must
+        # do this particular ordering, so that we get libvirtd
+        # running with socket activation in use
+        /bin/systemctl is-active libvirtd.service 1>/dev/null 2>&1
+        if test $? = 0
+        then
+            /bin/systemctl stop libvirtd.service >/dev/null 2>&1 || :
+
+            /bin/systemctl try-restart \
+                    libvirtd.socket \
+                    libvirtd-ro.socket \
+                    libvirtd-admin.socket >/dev/null 2>&1 || :
+
+            /bin/systemctl start libvirtd.service >/dev/null 2>&1 || :
+        fi
+    fi
+fi
+
+%libvirt_daemon_finish_restart libvirtd
+
+%post daemon-driver-network
+
+%if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtnetworkd
+%endif
+%libvirt_daemon_schedule_restart virtnetworkd
+
+%preun
+%libvirt_daemon_systemd_preun virtnetworkd
+
+%posttrans daemon-driver-network
+%libvirt_daemon_perform_restart virtnetworkd
+
+
+%post daemon-driver-nwfilter
+%if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtnwfilterd
+%endif
+%libvirt_daemon_schedule_restart virtnwfilterd
+
+%preun daemon-driver-nwfilter
+%libvirt_daemon_systemd_preun virtnwfilterd
+
+%posttrans daemon-driver-nwfilter
+%libvirt_daemon_perform_restart virtnwfilterd
+
+
+%post daemon-driver-nodedev
+%if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtnodedevd
+%endif
+%libvirt_daemon_schedule_restart virtnodedevd
+
+%preun daemon-driver-nodedev
+%libvirt_daemon_systemd_preun virtnodedevd
+
+%posttrans daemon-driver-nodedev
+%libvirt_daemon_perform_restart virtnodedevd
+
+
+%post daemon-driver-interface
+%if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtinterfaced
+%endif
+%libvirt_daemon_schedule_restart virtinterfaced
+
+%preun daemon-driver-interface
+%libvirt_daemon_systemd_preun virtinterfaced
+
+%posttrans daemon-driver-interface
+%libvirt_daemon_perform_restart virtinterfaced
+
+
+%post daemon-driver-secret
+%if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtsecretd
+%endif
+%libvirt_daemon_schedule_restart virtsecretd
+
+%preun daemon-driver-secret
+%libvirt_daemon_systemd_preun virtsecretd
+
+%posttrans daemon-driver-secret
+%libvirt_daemon_perform_restart virtsecretd
+
+
+%post daemon-driver-storage
+%if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtstoraged
+%endif
+%libvirt_daemon_schedule_restart virtstoraged
+
+%preun daemon-driver-storage
+%libvirt_daemon_systemd_preun virtstoraged
+
+%posttrans daemon-driver-storage
+%libvirt_daemon_perform_restart virtstoraged
+
+
+%if %{with_qemu}
+%post daemon-driver-qemu
+    %if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtqemud
+    %endif
+%libvirt_daemon_schedule_restart virtqemud
+
+%preun daemon-driver-qemu
+%libvirt_daemon_systemd_preun virtqemud
+
+%posttrans daemon-driver-qemu
+%libvirt_daemon_perform_restart virtqemud
+%endif
+
+
+%if %{with_lxc}
+%post daemon-driver-lxc
+    %if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtlxcd
+    %endif
+%libvirt_daemon_schedule_restart virtlxcd
+
+%preun daemon-driver-lxc
+%libvirt_daemon_systemd_preun virtlxcd
+
+%posttrans daemon-driver-lxc
+%libvirt_daemon_perform_restart virtlxcd
+%endif
+
+
+%if %{with_vbox}
+%post daemon-driver-vbox
+    %if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtvboxd
+    %endif
+%libvirt_daemon_schedule_restart virtvboxd
+
+%preun daemon-driver-vbox
+%libvirt_daemon_systemd_preun virtvboxd
+
+%posttrans daemon-driver-vbox
+%libvirt_daemon_perform_restart virtvboxd
+%endif
+
+
+%if %{with_libxl}
+%post daemon-driver-libxl
+    %if %{with_modular_daemons}
+%libvirt_daemon_systemd_post virtxend
+    %endif
+%libvirt_daemon_schedule_restart virtxend
+
+%preun daemon-driver-libxl
+%libvirt_daemon_systemd_preun virtxend
+
+%posttrans daemon-driver-libxl
+%libvirt_daemon_perform_restart virtxend
+%endif
+
+
+%post daemon-config-network
+if test $1 -eq 1 && test ! -f %{_sysconfdir}/libvirt/qemu/networks/default.xml ; then
+    # see if the network used by default network creates a conflict,
+    # and try to resolve it
+    # NB: 192.168.122.0/24 is used in the default.xml template file;
+    # do not modify any of those values here without also modifying
+    # them in the template.
+    orig_sub=122
+    sub=${orig_sub}
+    nl='
+'
+    routes="${nl}$(ip route show | cut -d' ' -f1)${nl}"
+    case ${routes} in
+      *"${nl}192.168.${orig_sub}.0/24${nl}"*)
+        # there was a match, so we need to look for an unused subnet
+        for new_sub in $(seq 124 254); do
+          case ${routes} in
+          *"${nl}192.168.${new_sub}.0/24${nl}"*)
+            ;;
+          *)
+            sub=$new_sub
+            break;
+            ;;
+          esac
+        done
+        ;;
+      *)
+        ;;
+    esac
+
+    sed -e "s/${orig_sub}/${sub}/g" \
+         < %{_datadir}/libvirt/networks/default.xml \
+         > %{_sysconfdir}/libvirt/qemu/networks/default.xml
+    ln -s ../default.xml %{_sysconfdir}/libvirt/qemu/networks/autostart/default.xml
+    # libvirt saves this file with mode 0600
+    chmod 0600 %{_sysconfdir}/libvirt/qemu/networks/default.xml
+
+    # Make sure libvirt picks up the new network defininiton
+    %libvirt_daemon_schedule_restart libvirtd
+    %libvirt_daemon_schedule_restart virtnetworkd
+fi
+
+%posttrans daemon-config-network
+%libvirt_daemon_perform_restart libvirtd
+%libvirt_daemon_perform_restart virtnetworkd
+
+%post daemon-config-nwfilter
+for datadir_file in %{_datadir}/libvirt/nwfilter/*.xml; do
+  sysconfdir_file=%{_sysconfdir}/libvirt/nwfilter/$(basename "$datadir_file")
+  if [ ! -f "$sysconfdir_file" ]; then
+    # libvirt saves these files with mode 600
+    install -m 0600 "$datadir_file" "$sysconfdir_file"
+  fi
+done
+# Make sure libvirt picks up the new nwfilter defininitons
+%libvirt_daemon_schedule_restart libvirtd
+%libvirt_daemon_schedule_restart virtnwfilterd
+
+%posttrans daemon-config-nwfilter
+%libvirt_daemon_perform_restart libvirtd
+%libvirt_daemon_perform_restart virtnwfilterd
+
+%if %{with_qemu}
+%pre daemon-driver-qemu
+# We want soft static allocation of well-known ids, as disk images
+# are commonly shared across NFS mounts by id rather than name; see
+# https://fedoraproject.org/wiki/Packaging:UsersAndGroups
+getent group kvm >/dev/null || groupadd -f -g 36 -r kvm
+getent group qemu >/dev/null || groupadd -f -g 107 -r qemu
+if ! getent passwd qemu >/dev/null; then
+  if ! getent passwd 107 >/dev/null; then
+    useradd -r -u 107 -g qemu -G kvm -d / -s /sbin/nologin -c "qemu user" qemu
+  else
+    useradd -r -g qemu -G kvm -d / -s /sbin/nologin -c "qemu user" qemu
+  fi
+fi
+exit 0
+%endif
+
+%if %{with_lxc}
+%pre login-shell
+getent group virtlogin >/dev/null || groupadd -r virtlogin
+exit 0
+%endif
+
+%files
+
+%files docs
+%doc AUTHORS.rst NEWS.rst README.rst
+%doc libvirt-docs/*
+
+%files daemon
+
+%dir %attr(0700, root, root) %{_sysconfdir}/libvirt/
+
+%{_unitdir}/libvirtd.service
+%{_unitdir}/libvirtd.socket
+%{_unitdir}/libvirtd-ro.socket
+%{_unitdir}/libvirtd-admin.socket
+%{_unitdir}/libvirtd-tcp.socket
+%{_unitdir}/libvirtd-tls.socket
+%{_unitdir}/virtproxyd.service
+%{_unitdir}/virtproxyd.socket
+%{_unitdir}/virtproxyd-ro.socket
+%{_unitdir}/virtproxyd-admin.socket
+%{_unitdir}/virtproxyd-tcp.socket
+%{_unitdir}/virtproxyd-tls.socket
+%{_unitdir}/virt-guest-shutdown.target
+%{_unitdir}/virtlogd.service
+%{_unitdir}/virtlogd.socket
+%{_unitdir}/virtlogd-admin.socket
+%{_unitdir}/virtlockd.service
+%{_unitdir}/virtlockd.socket
+%{_unitdir}/virtlockd-admin.socket
+%{_unitdir}/libvirt-guests.service
+%config(noreplace) %{_sysconfdir}/sysconfig/libvirtd
+%config(noreplace) %{_sysconfdir}/sysconfig/virtproxyd
+%config(noreplace) %{_sysconfdir}/sysconfig/virtlogd
+%config(noreplace) %{_sysconfdir}/sysconfig/virtlockd
+%config(noreplace) %{_sysconfdir}/libvirt/libvirtd.conf
+%config(noreplace) %{_sysconfdir}/libvirt/virtproxyd.conf
+%config(noreplace) %{_sysconfdir}/libvirt/virtlogd.conf
+%config(noreplace) %{_sysconfdir}/libvirt/virtlockd.conf
+%config(noreplace) %{_sysconfdir}/sasl2/libvirt.conf
+%config(noreplace) %{_sysconfdir}/sysconfig/libvirt-guests
+%config(noreplace) %{_prefix}/lib/sysctl.d/60-libvirtd.conf
+
+%config(noreplace) %{_sysconfdir}/logrotate.d/libvirtd
+%dir %{_datadir}/libvirt/
+
+%ghost %dir %{_rundir}/libvirt/
+
+%dir %attr(0711, root, root) %{_localstatedir}/lib/libvirt/images/
+%dir %attr(0711, root, root) %{_localstatedir}/lib/libvirt/filesystems/
+%dir %attr(0711, root, root) %{_localstatedir}/lib/libvirt/boot/
+%dir %attr(0711, root, root) %{_localstatedir}/cache/libvirt/
+
+
+%dir %attr(0755, root, root) %{_libdir}/libvirt/
+%dir %attr(0755, root, root) %{_libdir}/libvirt/connection-driver/
+%dir %attr(0755, root, root) %{_libdir}/libvirt/lock-driver
+%attr(0755, root, root) %{_libdir}/libvirt/lock-driver/lockd.so
+
+%{_datadir}/augeas/lenses/libvirtd.aug
+%{_datadir}/augeas/lenses/tests/test_libvirtd.aug
+%{_datadir}/augeas/lenses/virtlogd.aug
+%{_datadir}/augeas/lenses/tests/test_virtlogd.aug
+%{_datadir}/augeas/lenses/virtlockd.aug
+%{_datadir}/augeas/lenses/tests/test_virtlockd.aug
+%{_datadir}/augeas/lenses/virtproxyd.aug
+%{_datadir}/augeas/lenses/tests/test_virtproxyd.aug
+%{_datadir}/augeas/lenses/libvirt_lockd.aug
+%if %{with_qemu}
+%{_datadir}/augeas/lenses/tests/test_libvirt_lockd.aug
+%endif
+
+%{_datadir}/polkit-1/actions/org.libvirt.unix.policy
+%{_datadir}/polkit-1/actions/org.libvirt.api.policy
+%{_datadir}/polkit-1/rules.d/50-libvirt.rules
+
+%dir %attr(0700, root, root) %{_localstatedir}/log/libvirt/
+
+%attr(0755, root, root) %{_libexecdir}/libvirt_iohelper
+
+%attr(0755, root, root) %{_bindir}/virt-ssh-helper
+
+%attr(0755, root, root) %{_sbindir}/libvirtd
+%attr(0755, root, root) %{_sbindir}/virtproxyd
+%attr(0755, root, root) %{_sbindir}/virtlogd
+%attr(0755, root, root) %{_sbindir}/virtlockd
+%attr(0755, root, root) %{_libexecdir}/libvirt-guests.sh
+
+%{_mandir}/man1/virt-admin.1*
+%{_mandir}/man1/virt-host-validate.1*
+%{_mandir}/man8/libvirtd.8*
+%{_mandir}/man8/virtlogd.8*
+%{_mandir}/man8/virtlockd.8*
+%{_mandir}/man8/virtproxyd.8*
+%{_mandir}/man7/virkey*.7*
+
+%{_bindir}/virt-host-validate
+%{_bindir}/virt-admin
+%{_datadir}/bash-completion/completions/virt-admin
+
+%files daemon-config-network
+%dir %{_datadir}/libvirt/networks/
+%{_datadir}/libvirt/networks/default.xml
+%ghost %{_sysconfdir}/libvirt/qemu/networks/default.xml
+%ghost %{_sysconfdir}/libvirt/qemu/networks/autostart/default.xml
+
+%files daemon-config-nwfilter
+%dir %{_datadir}/libvirt/nwfilter/
+%{_datadir}/libvirt/nwfilter/*.xml
+%ghost %{_sysconfdir}/libvirt/nwfilter/*.xml
+
+%files daemon-driver-interface
+%config(noreplace) %{_sysconfdir}/sysconfig/virtinterfaced
+%config(noreplace) %{_sysconfdir}/libvirt/virtinterfaced.conf
+%{_datadir}/augeas/lenses/virtinterfaced.aug
+%{_datadir}/augeas/lenses/tests/test_virtinterfaced.aug
+%{_unitdir}/virtinterfaced.service
+%{_unitdir}/virtinterfaced.socket
+%{_unitdir}/virtinterfaced-ro.socket
+%{_unitdir}/virtinterfaced-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtinterfaced
+%{_libdir}/libvirt/connection-driver/libvirt_driver_interface.so
+%{_mandir}/man8/virtinterfaced.8*
+
+%files daemon-driver-network
+%config(noreplace) %{_sysconfdir}/sysconfig/virtnetworkd
+%config(noreplace) %{_sysconfdir}/libvirt/virtnetworkd.conf
+%{_datadir}/augeas/lenses/virtnetworkd.aug
+%{_datadir}/augeas/lenses/tests/test_virtnetworkd.aug
+%{_unitdir}/virtnetworkd.service
+%{_unitdir}/virtnetworkd.socket
+%{_unitdir}/virtnetworkd-ro.socket
+%{_unitdir}/virtnetworkd-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtnetworkd
+%dir %attr(0700, root, root) %{_sysconfdir}/libvirt/qemu/
+%dir %attr(0700, root, root) %{_sysconfdir}/libvirt/qemu/networks/
+%dir %attr(0700, root, root) %{_sysconfdir}/libvirt/qemu/networks/autostart
+%ghost %dir %{_rundir}/libvirt/network/
+%dir %attr(0700, root, root) %{_localstatedir}/lib/libvirt/network/
+%dir %attr(0755, root, root) %{_localstatedir}/lib/libvirt/dnsmasq/
+%attr(0755, root, root) %{_libexecdir}/libvirt_leaseshelper
+%{_libdir}/libvirt/connection-driver/libvirt_driver_network.so
+%{_mandir}/man8/virtnetworkd.8*
+
+%if %{with_firewalld_zone}
+%{_prefix}/lib/firewalld/zones/libvirt.xml
+%endif
+
+%files daemon-driver-nodedev
+%config(noreplace) %{_sysconfdir}/sysconfig/virtnodedevd
+%config(noreplace) %{_sysconfdir}/libvirt/virtnodedevd.conf
+%{_datadir}/augeas/lenses/virtnodedevd.aug
+%{_datadir}/augeas/lenses/tests/test_virtnodedevd.aug
+%{_unitdir}/virtnodedevd.service
+%{_unitdir}/virtnodedevd.socket
+%{_unitdir}/virtnodedevd-ro.socket
+%{_unitdir}/virtnodedevd-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtnodedevd
+%{_libdir}/libvirt/connection-driver/libvirt_driver_nodedev.so
+%{_mandir}/man8/virtnodedevd.8*
+
+%files daemon-driver-nwfilter
+%config(noreplace) %{_sysconfdir}/sysconfig/virtnwfilterd
+%config(noreplace) %{_sysconfdir}/libvirt/virtnwfilterd.conf
+%{_datadir}/augeas/lenses/virtnwfilterd.aug
+%{_datadir}/augeas/lenses/tests/test_virtnwfilterd.aug
+%{_unitdir}/virtnwfilterd.service
+%{_unitdir}/virtnwfilterd.socket
+%{_unitdir}/virtnwfilterd-ro.socket
+%{_unitdir}/virtnwfilterd-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtnwfilterd
+%dir %attr(0700, root, root) %{_sysconfdir}/libvirt/nwfilter/
+%ghost %dir %{_rundir}/libvirt/network/
+%{_libdir}/libvirt/connection-driver/libvirt_driver_nwfilter.so
+%{_mandir}/man8/virtnwfilterd.8*
+
+%files daemon-driver-secret
+%config(noreplace) %{_sysconfdir}/sysconfig/virtsecretd
+%config(noreplace) %{_sysconfdir}/libvirt/virtsecretd.conf
+%{_datadir}/augeas/lenses/virtsecretd.aug
+%{_datadir}/augeas/lenses/tests/test_virtsecretd.aug
+%{_unitdir}/virtsecretd.service
+%{_unitdir}/virtsecretd.socket
+%{_unitdir}/virtsecretd-ro.socket
+%{_unitdir}/virtsecretd-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtsecretd
+%{_libdir}/libvirt/connection-driver/libvirt_driver_secret.so
+%{_mandir}/man8/virtsecretd.8*
+
+%files daemon-driver-storage
+
+%files daemon-driver-storage-core
+%config(noreplace) %{_sysconfdir}/sysconfig/virtstoraged
+%config(noreplace) %{_sysconfdir}/libvirt/virtstoraged.conf
+%{_datadir}/augeas/lenses/virtstoraged.aug
+%{_datadir}/augeas/lenses/tests/test_virtstoraged.aug
+%{_unitdir}/virtstoraged.service
+%{_unitdir}/virtstoraged.socket
+%{_unitdir}/virtstoraged-ro.socket
+%{_unitdir}/virtstoraged-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtstoraged
+%attr(0755, root, root) %{_libexecdir}/libvirt_parthelper
+%{_libdir}/libvirt/connection-driver/libvirt_driver_storage.so
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_fs.so
+%{_libdir}/libvirt/storage-file/libvirt_storage_file_fs.so
+%{_mandir}/man8/virtstoraged.8*
+
+%files daemon-driver-storage-disk
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_disk.so
+
+%files daemon-driver-storage-logical
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_logical.so
+
+%files daemon-driver-storage-scsi
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_scsi.so
+
+%files daemon-driver-storage-iscsi
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_iscsi.so
+
+%if %{with_storage_iscsi_direct}
+%files daemon-driver-storage-iscsi-direct
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_iscsi-direct.so
+%endif
+
+%files daemon-driver-storage-mpath
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_mpath.so
+
+%if %{with_storage_gluster}
+%files daemon-driver-storage-gluster
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_gluster.so
+%{_libdir}/libvirt/storage-file/libvirt_storage_file_gluster.so
+%endif
+
+%if %{with_storage_rbd}
+%files daemon-driver-storage-rbd
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_rbd.so
+%endif
+
+%if %{with_storage_sheepdog}
+%files daemon-driver-storage-sheepdog
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_sheepdog.so
+%endif
+
+%if %{with_storage_zfs}
+%files daemon-driver-storage-zfs
+%{_libdir}/libvirt/storage-backend/libvirt_storage_backend_zfs.so
+%endif
+
+%if %{with_qemu}
+%files daemon-driver-qemu
+%config(noreplace) %{_sysconfdir}/sysconfig/virtqemud
+%config(noreplace) %{_sysconfdir}/libvirt/virtqemud.conf
+%{_datadir}/augeas/lenses/virtqemud.aug
+%{_datadir}/augeas/lenses/tests/test_virtqemud.aug
+%{_unitdir}/virtqemud.service
+%{_unitdir}/virtqemud.socket
+%{_unitdir}/virtqemud-ro.socket
+%{_unitdir}/virtqemud-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtqemud
+%dir %attr(0700, root, root) %{_sysconfdir}/libvirt/qemu/
+%dir %attr(0700, root, root) %{_localstatedir}/log/libvirt/qemu/
+%config(noreplace) %{_sysconfdir}/libvirt/qemu.conf
+%config(noreplace) %{_sysconfdir}/libvirt/qemu-lockd.conf
+%config(noreplace) %{_sysconfdir}/logrotate.d/libvirtd.qemu
+%ghost %dir %{_rundir}/libvirt/qemu/
+%dir %attr(0751, %{qemu_user}, %{qemu_group}) %{_localstatedir}/lib/libvirt/qemu/
+%dir %attr(0750, %{qemu_user}, %{qemu_group}) %{_localstatedir}/cache/libvirt/qemu/
+%{_datadir}/augeas/lenses/libvirtd_qemu.aug
+%{_datadir}/augeas/lenses/tests/test_libvirtd_qemu.aug
+%{_libdir}/libvirt/connection-driver/libvirt_driver_qemu.so
+%dir %attr(0711, root, root) %{_localstatedir}/lib/libvirt/swtpm/
+%dir %attr(0730, tss, tss) %{_localstatedir}/log/swtpm/libvirt/qemu/
+%{_bindir}/virt-qemu-run
+%{_mandir}/man1/virt-qemu-run.1*
+%{_mandir}/man8/virtqemud.8*
+%endif
+
+%if %{with_lxc}
+%files daemon-driver-lxc
+%config(noreplace) %{_sysconfdir}/sysconfig/virtlxcd
+%config(noreplace) %{_sysconfdir}/libvirt/virtlxcd.conf
+%{_datadir}/augeas/lenses/virtlxcd.aug
+%{_datadir}/augeas/lenses/tests/test_virtlxcd.aug
+%{_unitdir}/virtlxcd.service
+%{_unitdir}/virtlxcd.socket
+%{_unitdir}/virtlxcd-ro.socket
+%{_unitdir}/virtlxcd-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtlxcd
+%dir %attr(0700, root, root) %{_localstatedir}/log/libvirt/lxc/
+%config(noreplace) %{_sysconfdir}/libvirt/lxc.conf
+%config(noreplace) %{_sysconfdir}/logrotate.d/libvirtd.lxc
+%ghost %dir %{_rundir}/libvirt/lxc/
+%dir %attr(0700, root, root) %{_localstatedir}/lib/libvirt/lxc/
+%{_datadir}/augeas/lenses/libvirtd_lxc.aug
+%{_datadir}/augeas/lenses/tests/test_libvirtd_lxc.aug
+%attr(0755, root, root) %{_libexecdir}/libvirt_lxc
+%{_libdir}/libvirt/connection-driver/libvirt_driver_lxc.so
+%{_mandir}/man8/virtlxcd.8*
+%endif
+
+%if %{with_libxl}
+%files daemon-driver-libxl
+%config(noreplace) %{_sysconfdir}/sysconfig/virtxend
+%config(noreplace) %{_sysconfdir}/libvirt/virtxend.conf
+%{_datadir}/augeas/lenses/virtxend.aug
+%{_datadir}/augeas/lenses/tests/test_virtxend.aug
+%{_unitdir}/virtxend.service
+%{_unitdir}/virtxend.socket
+%{_unitdir}/virtxend-ro.socket
+%{_unitdir}/virtxend-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtxend
+%config(noreplace) %{_sysconfdir}/libvirt/libxl.conf
+%config(noreplace) %{_sysconfdir}/logrotate.d/libvirtd.libxl
+%config(noreplace) %{_sysconfdir}/libvirt/libxl-lockd.conf
+%{_datadir}/augeas/lenses/libvirtd_libxl.aug
+%{_datadir}/augeas/lenses/tests/test_libvirtd_libxl.aug
+%dir %attr(0700, root, root) %{_localstatedir}/log/libvirt/libxl/
+%ghost %dir %{_rundir}/libvirt/libxl/
+%dir %attr(0700, root, root) %{_localstatedir}/lib/libvirt/libxl/
+%{_libdir}/libvirt/connection-driver/libvirt_driver_libxl.so
+%{_mandir}/man8/virtxend.8*
+%endif
+
+%if %{with_vbox}
+%files daemon-driver-vbox
+%config(noreplace) %{_sysconfdir}/sysconfig/virtvboxd
+%config(noreplace) %{_sysconfdir}/libvirt/virtvboxd.conf
+%{_datadir}/augeas/lenses/virtvboxd.aug
+%{_datadir}/augeas/lenses/tests/test_virtvboxd.aug
+%{_unitdir}/virtvboxd.service
+%{_unitdir}/virtvboxd.socket
+%{_unitdir}/virtvboxd-ro.socket
+%{_unitdir}/virtvboxd-admin.socket
+%attr(0755, root, root) %{_sbindir}/virtvboxd
+%{_libdir}/libvirt/connection-driver/libvirt_driver_vbox.so
+%{_mandir}/man8/virtvboxd.8*
+%endif
+
+%if %{with_qemu_tcg}
+%files daemon-qemu
+%endif
+
+%if %{with_qemu_kvm}
+%files daemon-kvm
+%endif
+
+%if %{with_lxc}
+%files daemon-lxc
+%endif
+
+%if %{with_libxl}
+%files daemon-xen
+%endif
+
+%if %{with_vbox}
+%files daemon-vbox
+%endif
+
+%if %{with_sanlock}
+%files lock-sanlock
+    %if %{with_qemu}
+%config(noreplace) %{_sysconfdir}/libvirt/qemu-sanlock.conf
+    %endif
+    %if %{with_libxl}
+%config(noreplace) %{_sysconfdir}/libvirt/libxl-sanlock.conf
+    %endif
+%attr(0755, root, root) %{_libdir}/libvirt/lock-driver/sanlock.so
+%{_datadir}/augeas/lenses/libvirt_sanlock.aug
+%{_datadir}/augeas/lenses/tests/test_libvirt_sanlock.aug
+%dir %attr(0770, root, sanlock) %{_localstatedir}/lib/libvirt/sanlock
+%{_sbindir}/virt-sanlock-cleanup
+%{_mandir}/man8/virt-sanlock-cleanup.8*
+%attr(0755, root, root) %{_libexecdir}/libvirt_sanlock_helper
+%endif
+
+%files client
+%{_mandir}/man1/virsh.1*
+%{_mandir}/man1/virt-xml-validate.1*
+%{_mandir}/man1/virt-pki-validate.1*
+%{_bindir}/virsh
+%{_bindir}/virt-xml-validate
+%{_bindir}/virt-pki-validate
+%{_bindir}/virt-pki-query-dn
+
+%{_datadir}/bash-completion/completions/virsh
+
+%files libs -f libvirt.lang
+%license COPYING COPYING.LESSER
+%config(noreplace) %{_sysconfdir}/libvirt/libvirt.conf
+%config(noreplace) %{_sysconfdir}/libvirt/libvirt-admin.conf
+%{_libdir}/libvirt.so.*
+%{_libdir}/libvirt-qemu.so.*
+%{_libdir}/libvirt-lxc.so.*
+%{_libdir}/libvirt-admin.so.*
+%dir %{_datadir}/libvirt/
+%dir %{_datadir}/libvirt/schemas/
+%dir %attr(0755, root, root) %{_localstatedir}/lib/libvirt/
+
+%{_datadir}/systemtap/tapset/libvirt_probes*.stp
+%{_datadir}/systemtap/tapset/libvirt_functions.stp
+%if %{with_qemu}
+%{_datadir}/systemtap/tapset/libvirt_qemu_probes*.stp
+%endif
+
+%{_datadir}/libvirt/schemas/*.rng
+
+%{_datadir}/libvirt/cpu_map/*.xml
+
+%{_datadir}/libvirt/test-screenshot.png
+
+%if %{with_wireshark}
+%files wireshark
+%{wireshark_plugindir}/libvirt.so
+%endif
+
+%files nss
+%{_libdir}/libnss_libvirt.so.2
+%{_libdir}/libnss_libvirt_guest.so.2
+
+%if %{with_lxc}
+%files login-shell
+%attr(4750, root, virtlogin) %{_bindir}/virt-login-shell
+%{_libexecdir}/virt-login-shell-helper
+%config(noreplace) %{_sysconfdir}/libvirt/virt-login-shell.conf
+%{_mandir}/man1/virt-login-shell.1*
+%endif
+
+%files devel
+%{_libdir}/libvirt.so
+%{_libdir}/libvirt-admin.so
+%{_libdir}/libvirt-qemu.so
+%{_libdir}/libvirt-lxc.so
+%dir %{_includedir}/libvirt
+%{_includedir}/libvirt/virterror.h
+%{_includedir}/libvirt/libvirt.h
+%{_includedir}/libvirt/libvirt-admin.h
+%{_includedir}/libvirt/libvirt-common.h
+%{_includedir}/libvirt/libvirt-domain.h
+%{_includedir}/libvirt/libvirt-domain-checkpoint.h
+%{_includedir}/libvirt/libvirt-domain-snapshot.h
+%{_includedir}/libvirt/libvirt-event.h
+%{_includedir}/libvirt/libvirt-host.h
+%{_includedir}/libvirt/libvirt-interface.h
+%{_includedir}/libvirt/libvirt-network.h
+%{_includedir}/libvirt/libvirt-nodedev.h
+%{_includedir}/libvirt/libvirt-nwfilter.h
+%{_includedir}/libvirt/libvirt-secret.h
+%{_includedir}/libvirt/libvirt-storage.h
+%{_includedir}/libvirt/libvirt-stream.h
+%{_includedir}/libvirt/libvirt-qemu.h
+%{_includedir}/libvirt/libvirt-lxc.h
+%{_libdir}/pkgconfig/libvirt.pc
+%{_libdir}/pkgconfig/libvirt-admin.pc
+%{_libdir}/pkgconfig/libvirt-qemu.pc
+%{_libdir}/pkgconfig/libvirt-lxc.pc
+
+%dir %{_datadir}/libvirt/api/
+%{_datadir}/libvirt/api/libvirt-api.xml
+%{_datadir}/libvirt/api/libvirt-admin-api.xml
+%{_datadir}/libvirt/api/libvirt-qemu-api.xml
+%{_datadir}/libvirt/api/libvirt-lxc-api.xml
+
+
+%changelog


### PR DESCRIPTION
1. Upstream libvirt need to be modified for TDX VM like type of <launchSecurity>, OVMF loader etc.
2. Current implementation support:
   - mrOwner hash for launch security
   - Secure boot for TD VM
   - hard reboot via virsh for TD VM

Signed-off-by: Lu Ken <ken.lu@intel.com>