### PR TITLE
Resolve conflicts and obsoletes

### DIFF
--- a/build/centos-stream-8/intel-mvp-tdx-guest-grub2/grub.macros
+++ b/build/centos-stream-8/intel-mvp-tdx-guest-grub2/grub.macros
@@ -218,7 +218,7 @@
 
 %ifarch x86_64
 %global with_efi_common 1
-%global with_legacy_modules 0
+%global with_legacy_modules 1
 %global with_legacy_common 0
 %else
 %global with_efi_common 0
@@ -231,13 +231,13 @@
 Summary:	Bootloader with support for Linux, Multiboot, and more	\
 Group:		System Environment/Base					\
 Provides:	%{generic_name} = %{evr}					\
-Obsoletes:	%{generic_name} < %{evr}					\
-Requires:	%{generic_name}-common = %{evr}					\
-Requires:	%{generic_name}-tools-minimal = %{evr}				\
-Requires:	%{generic_name}-%{1}-modules = %{evr}				\
+Obsoletes:	%{generic_name}-%{1}					\
+Requires:	%{name}-common = %{evr}					\
+Requires:	%{name}-tools-minimal = %{evr}				\
+Requires:	%{name}-%{1}-modules = %{evr}				\
 Requires:	gettext which file					\
-Requires:	%{generic_name}-tools-extra = %{evr}				\
-Requires:	%{generic_name}-tools = %{evr}					\
+Requires:	%{name}-tools-extra = %{evr}				\
+Requires:	%{name}-tools = %{evr}					\
 Requires(pre):	dracut							\
 Requires(post): dracut							\
 %{expand:%%description %%{1}}						\
@@ -250,7 +250,8 @@ This subpackage provides support for %%{1} systems.			\
 Summary:	Modules used to build custom grub images		\
 Group:		System Environment/Base					\
 BuildArch:	noarch							\
-Requires:	%%{generic_name}-common = %%{evr}				\
+Requires:	%%{name}-common = %%{evr}				\
+Obsoletes:	%{generic_name}-%{1}-modules					\
 %%description %%{1}-modules						\
 %%{desc}								\
 This subpackage provides support for rebuilding your own grub.efi.	\
@@ -262,8 +263,8 @@ This subpackage provides support for rebuilding your own grub.efi.	\
 Summary:	Support tools for GRUB.					\
 Group:		System Environment/Base					\
 Requires:	gettext os-prober which file system-logos		\
-Requires:	%{generic_name}-common = %{evr}					\
-Requires:	%{generic_name}-tools-minimal = %{evr}				\
+Requires:	%{name}-common = %{evr}					\
+Requires:	%{name}-tools-minimal = %{evr}				\
 Requires:	os-prober >= 1.58-11					\
 Requires:	gettext which file					\
 									\
@@ -277,13 +278,13 @@ This subpackage provides tools for support of %%{1} platforms.		\
 Summary:	GRUB for EFI systems.					\
 Group:		System Environment/Base					\
 Requires:	efi-filesystem						\
-Requires:	%{generic_name}-common = %{evr}					\
-Requires:	%{generic_name}-tools-minimal >= %{evr}				\
-Requires:	%{generic_name}-tools-extra = %{evr}				\
-Requires:	%{generic_name}-tools = %{evr}					\
+Requires:	%{name}-common = %{evr}					\
+Requires:	%{name}-tools-minimal >= %{evr}				\
+Requires:	%{name}-tools-extra = %{evr}				\
+Requires:	%{name}-tools = %{evr}					\
 Provides:	%{generic_name}-efi = %{evr}					\
-%{?legacy_provides:Provides:	%{generic_name} = %{evr}}			\
-%{-o:Obsoletes:	%{generic_name}-efi < %{evr}}					\
+%{?legacy_provides:Provides:	%{name} = %{evr}}			\
+%{-o:Obsoletes:	%{generic_name}-efi}					\
 									\
 %{expand:%%description %{1}}						\
 %{desc}									\
@@ -295,9 +296,9 @@ This subpackage provides support for %{1} systems.			\
 Summary:	Modules used to build custom grub.efi images		\
 Group:		System Environment/Base					\
 BuildArch:	noarch							\
-Requires:	%{generic_name}-common = %{evr}					\
+Requires:	%{name}-common = %{evr}					\
 Provides:	%{generic_name}-efi-modules = %{evr}				\
-Obsoletes:	%{generic_name}-efi-modules < %{evr}				\
+Obsoletes:	%{generic_name}-efi-modules				\
 %{expand:%%description %{1}-modules}					\
 %{desc}									\
 This subpackage provides support for rebuilding your own grub.efi.	\
@@ -306,7 +307,7 @@ This subpackage provides support for rebuilding your own grub.efi.	\
 %{expand:%%package %{1}-cdboot}						\
 Summary:	Files used to boot removeable media with EFI		\
 Group:		System Environment/Base					\
-Requires:	%{generic_name}-common = %{evr}					\
+Requires:	%{name}-common = %{evr}					\
 Provides:	%{generic_name}-efi-cdboot = %{evr}				\
 %{expand:%%description %{1}-cdboot}					\
 %{desc}									\

--- a/build/centos-stream-8/intel-mvp-tdx-guest-grub2/tdx-guest-grub2.spec
+++ b/build/centos-stream-8/intel-mvp-tdx-guest-grub2/tdx-guest-grub2.spec
@@ -67,12 +67,12 @@ BuildRequires:	ccache
 %endif
 
 ExcludeArch:	s390 s390x %{arm}
-Obsoletes:	%{generic_name} <= %{evr}
+Obsoletes:	%{generic_name}
 
 %if 0%{with_legacy_arch}
-Requires:	%{generic_name}-%{legacy_package_arch} = %{evr}
+Requires:	%{name}-%{legacy_package_arch} = %{evr}
 %else
-Requires:	%{generic_name}-%{package_arch} = %{evr}
+Requires:	%{name}-%{package_arch} = %{evr}
 %endif
 
 %if 0%{?centos}
@@ -94,8 +94,8 @@ Summary:	grub2 common layout
 Group:		System Environment/Base
 BuildArch:	noarch
 Conflicts:	grubby < 8.40-13
-Provides:	grub2-common
-Obsoletes:	grub2-common
+Provides:	%{generic_name}-common
+Obsoletes:	%{generic_name}-common
 
 %description common
 This package provides some directories which are required by various grub2
@@ -104,9 +104,9 @@ subpackages.
 %package tools
 Summary:	Support tools for GRUB.
 Group:		System Environment/Base
-Obsoletes:	%{generic_name}-tools < %{evr}
+Obsoletes:	%{generic_name}-tools
 Provides:	%{generic_name}-tools
-Requires:	%{generic_name}-common = %{epoch}:%{version}-%{release}
+Requires:	%{name}-common = %{epoch}:%{version}-%{release}
 Requires:	gettext os-prober which file
 Requires(pre):	dracut
 Requires(post):	dracut
@@ -120,8 +120,8 @@ This subpackage provides tools for support of all platforms.
 Summary:	Support tools for GRUB.
 Group:		System Environment/Base
 Requires:	gettext os-prober which file
-Requires:	%{generic_name}-common = %{epoch}:%{version}-%{release}
-Obsoletes:	%{generic_name}-tools < %{evr}
+Requires:	%{name}-common = %{epoch}:%{version}-%{release}
+Obsoletes:	%{generic_name}-efi
 
 %description tools-efi
 %{desc}
@@ -132,8 +132,9 @@ This subpackage provides tools for support of EFI platforms.
 Summary:	Support tools for GRUB.
 Group:		System Environment/Base
 Requires:	gettext
-Requires:	%{generic_name}-common = %{epoch}:%{version}-%{release}
-Obsoletes:	%{generic_name}-tools < %{evr}
+Requires:	%{name}-common = %{epoch}:%{version}-%{release}
+Obsoletes:	%{generic_name}-tools-minimal
+Provides:	%{generic_name}-tools-minimal
 
 %description tools-minimal
 %{desc}
@@ -143,9 +144,10 @@ This subpackage provides tools for support of all platforms.
 Summary:	Support tools for GRUB.
 Group:		System Environment/Base
 Requires:	gettext os-prober which file
-Requires:	%{generic_name}-tools-minimal = %{epoch}:%{version}-%{release}
-Requires:	%{generic_name}-common = %{epoch}:%{version}-%{release}
-Obsoletes:	%{generic_name}-tools < %{evr}
+Requires:	%{name}-tools-minimal = %{epoch}:%{version}-%{release}
+Requires:	%{name}-common = %{epoch}:%{version}-%{release}
+Obsoletes:	%{generic_name}-tools-extra
+Provides:	%{generic_name}-tools-extra
 
 %description tools-extra
 %{desc}


### PR DESCRIPTION
Obsolete grub2-pc, grub2-tools-minimal, grub2-tools-extra.
Enable legacy grub2-pc-modules.

Signed-off-by: Jialei Feng <jialei.feng@intel.com>