### PR TITLE
tdx-host-kernel.spec: remove dependency on tdx-module package

### DIFF
--- a/build/centos-stream-8/intel-mvp-tdx-host-kernel/tdx-host-kernel.spec
+++ b/build/centos-stream-8/intel-mvp-tdx-host-kernel/tdx-host-kernel.spec
@@ -725,7 +725,6 @@ Requires(pre): %{kernel_prereq}\
 Requires(pre): %{initrd_prereq}\
 Requires(pre): linux-firmware >= 20150904-56.git6ebf5d57\
 Requires(preun): systemd >= 200\
-Requires: intel-mvp-tdx-module\
 Conflicts: xfsprogs < 4.3.0-1\
 Conflicts: xorg-x11-drv-vmmouse < 13.0.99\
 %{expand:%%{?kernel%{?1:_%{1}}_conflicts:Conflicts: %%{kernel%{?1:_%{1}}_conflicts}}}\


### PR DESCRIPTION
We don't publish a tdx-module package yet. Remove this dependency so
that the host kernel can at least be installed, even though TDX will
not be available without the module.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>