### PR TITLE
upstream branch changed from rhel-8.4 to rhel-8.4.0

### DIFF
--- a/build/centos-stream-8/intel-mvp-tdx-guest-grub2/build.sh
+++ b/build/centos-stream-8/intel-mvp-tdx-guest-grub2/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 UPSTREAM_GIT_URI="https://github.com/rhboot/grub2.git"
-UPSTREAM_BRANCH="rhel-8.4"
+UPSTREAM_BRANCH="rhel-8.4.0"
 DOWNSTREAM_GIT_URI="https://github.com/intel/grub-tdx.git"
 DOWNSTREAM_BRANCH="2.02-rhel-8.4"
 


### PR DESCRIPTION
rhel-8.4 has been changed to rhel-8.4.0 in https://github.com/rhboot/grub2.git

Signed-off-by: jialeie <jialei.feng@intel.com>