### PR TITLE
Use downstream tag and pin upstream base commit for grub and shim

### DIFF
--- a/build/centos-stream-8/intel-mvp-tdx-guest-grub2/build.sh
+++ b/build/centos-stream-8/intel-mvp-tdx-guest-grub2/build.sh
@@ -2,15 +2,15 @@
 
 set -e
 
-UPSTREAM_GIT_URI="https://github.com/rhboot/grub2.git"
-UPSTREAM_BRANCH="rhel-8.4.0"
+UPSTREAM_BASE_COMMIT=52823acbf284ae050e3f63590548bfe515c743c8
 DOWNSTREAM_GIT_URI="https://github.com/intel/grub-tdx.git"
-DOWNSTREAM_BRANCH="2.02-rhel-8.4"
+DOWNSTREAM_TAG="tdx-guest-rhel-8.5-2021.11.22"
 
 CURR_DIR=$(dirname "$(readlink -f "$0")")
 RPMBUILD_DIR=$CURR_DIR/rpmbuild
 PATCH_SET=patches-tdx-grub-2.02
 SPEC=$CURR_DIR/tdx-guest-grub2.spec
+REPO_DIR=grub-2.02
 
 pushd "$CURR_DIR"
 mkdir -p $PATCH_SET
@@ -23,16 +23,15 @@ generate() {
     fi
 
     echo "**** Generate tdx patchset and upstream tarball ****"
-    rm -rf grub-2.02
-    git clone -b $DOWNSTREAM_BRANCH --single-branch $DOWNSTREAM_GIT_URI grub-2.02
-    cd grub-2.02
-    upstream_base=$(git ls-remote $UPSTREAM_GIT_URI refs/heads/$UPSTREAM_BRANCH | cut -f 1)
-    git format-patch "$upstream_base"..$DOWNSTREAM_BRANCH
-    git checkout "$upstream_base"
+    rm -rf $REPO_DIR
+    git clone -b $DOWNSTREAM_TAG --single-branch $DOWNSTREAM_GIT_URI $REPO_DIR
+    cd $REPO_DIR
+    git format-patch $UPSTREAM_BASE_COMMIT..$DOWNSTREAM_TAG
+    git checkout $UPSTREAM_BASE_COMMIT
     cd ..
-    mv grub-2.02/*.patch $PATCH_SET/
-    tar --exclude=.git --exclude=.gitignore -czf "$RPMBUILD_DIR"/SOURCES/grub-2.02.tar.gz grub-2.02
-    rm -rf grub-2.02
+    mv $REPO_DIR/*.patch $PATCH_SET/
+    tar --exclude=.git --exclude=.gitignore -czf "$RPMBUILD_DIR"/SOURCES/$REPO_DIR.tar.gz $REPO_DIR
+    rm -rf $REPO_DIR
 }
 
 prepare() {

--- a/build/centos-stream-8/intel-mvp-tdx-guest-grub2/tdx-guest-grub2.spec
+++ b/build/centos-stream-8/intel-mvp-tdx-guest-grub2/tdx-guest-grub2.spec
@@ -12,7 +12,7 @@
 Name:		intel-mvp-tdx-guest-grub2
 Epoch:		1
 Version:	2.02
-Release:	106.mvp4%{?dist}
+Release:	106.mvp5%{?dist}
 Summary:	Bootloader with support for Linux, Multiboot and more
 Group:		System Environment/Base
 License:	GPLv3+

--- a/build/centos-stream-8/intel-mvp-tdx-guest-shim/build.sh
+++ b/build/centos-stream-8/intel-mvp-tdx-guest-shim/build.sh
@@ -2,10 +2,9 @@
 
 set -e
 
-UPSTREAM_GIT_URI="https://github.com/rhboot/shim.git"
-UPSTREAM_BRANCH="shim-15.4"
+UPSTREAM_BASE_COMMIT="16eeafe28c552bca36953d75581500887631a7f1"
 DOWNSTREAM_GIT_URI="https://github.com/intel/shim-tdx.git"
-DOWNSTREAM_BRANCH="tdx-shim-15.4"
+DOWNSTREAM_TAG="tdx-guest-rhel-8.4-2021.11.22"
 
 CURR_DIR=$(dirname "$(readlink -f "$0")")
 RPMBUILD_DIR=$CURR_DIR/rpmbuild
@@ -25,11 +24,10 @@ generate() {
 
     echo "**** Generate tdx patchset and upstream tarball ****"
     rm -rf $REPO_DIR
-    git clone -b $DOWNSTREAM_BRANCH --single-branch --recurse-submodules $DOWNSTREAM_GIT_URI $REPO_DIR
+    git clone -b $DOWNSTREAM_TAG --single-branch --recurse-submodules $DOWNSTREAM_GIT_URI $REPO_DIR
     cd $REPO_DIR
-    upstream_base=$(git ls-remote $UPSTREAM_GIT_URI refs/heads/$UPSTREAM_BRANCH | cut -f 1)
-    git format-patch "$upstream_base"..$DOWNSTREAM_BRANCH
-    git checkout "$upstream_base"
+    git format-patch $UPSTREAM_BASE_COMMIT..$DOWNSTREAM_TAG
+    git checkout $UPSTREAM_BASE_COMMIT
     cd ..
     mv $REPO_DIR/*.patch $PATCH_SET/
     tar --exclude=.git --exclude=.gitignore -czf "$RPMBUILD_DIR"/SOURCES/$REPO_DIR.tar.gz $REPO_DIR


### PR DESCRIPTION
Make grub and shim build tools more robust.
There are several new commits recently(03/09) in upstream branch, so the
base commit has changed. Refer to https://github.com/rhboot/grub2/

Signed-off-by: jialeie <jialei.feng@intel.com>