### PR TITLE
Fix pylint issues for test modules

### DIFF
--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -10,6 +10,9 @@ from pycloudstack.vmguest import VMGuestFactory
 
 LOG = logging.getLogger(__name__)
 
+# Disable redefined-outer-name since it is false positive for pytest's fixture
+# pylint: disable=redefined-outer-name
+
 
 @pytest.fixture(scope="module")
 def vm_name(request):
@@ -118,6 +121,9 @@ def artifact_factory():
 
 
 def pytest_addoption(parser):
+    """
+    The flag to keep VM without destroy for advanced debugging
+    """
     parser.addoption(
         "--keep-vm", action="store_true", default=False, help="NOT destroy unhealty VMs"
     )

--- a/tests/tests/test_tdvm_tsc.py
+++ b/tests/tests/test_tdvm_tsc.py
@@ -14,6 +14,9 @@ from pycloudstack.vmparam import VM_TYPE_TD
 
 __author__ = 'cpio'
 
+# Disable redefined-outer-name since it is false positive for pytest's fixture
+# pylint: disable=redefined-outer-name
+
 LOG = logging.getLogger(__name__)
 
 DATE_SUFFIX = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/tests/tests/test_tdx_guest_status.py
+++ b/tests/tests/test_tdx_guest_status.py
@@ -11,6 +11,9 @@ from pycloudstack.vmparam import VM_TYPE_TD
 
 __author__ = 'cpio'
 
+# Disable redefined-outer-name since it is false positive for pytest's fixture
+# pylint: disable=redefined-outer-name
+
 LOG = logging.getLogger(__name__)
 
 DATE_SUFFIX = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")


### PR DESCRIPTION
1. Disable redefined-outer-name warning since it is false positive for pytest's fixture approach
2. Convert the CRLF style => LF style for conftest.py

Signed-off-by: Lu Ken <ken.lu@intel.com>