### PR TITLE
Clean up tdx_disable_filter flag for security consideration

### DIFF
--- a/start-qemu.sh
+++ b/start-qemu.sh
@@ -166,6 +166,9 @@ process_args() {
         case ${QUOTE_TYPE} in
             "tdvmcall") ;;
             "vsock")
+                # vsock is filtered by guest kernel by default due to security consideration
+                # so if using vsock to get TDREPORT, tdx_disable_filter is required as a
+                # workaround. It is recommend to use tdvmcall approach instead of vsock
                 KERNEL_CMD_TD+=" tdx_disable_filter"
                 USE_VSOCK=true
                 ;;

--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -74,10 +74,6 @@ class VMGuest:
             assert self.kernel is not None
             assert os.path.exists(self.kernel)
             self.kernel = os.path.realpath(self.kernel)
-            if self.vmtype == VM_TYPE_TD:
-                self.cmdline += "tdx_disable_filter"
-            else:
-                self.cmdline.remove_field_from_string("tdx_disable_filter")
         self.vmm = vmm_class(self)
 
     def ssh_run(self, cmdarr, ssh_id_key, no_wait=False):
@@ -403,15 +399,13 @@ class VMGuestFactory:
         if not self._keep_issue_vm:
             inst.image.destroy()
             inst.destroy()
-            # pylint: disable=consider-iterating-dictionary
-            if inst.nam in self.vms.keys():
+            if inst.name in self.vms:
                 del self.vms[inst.name]
         else:
             if inst.state() is VM_STATE_RUNNING and not inst.keep:
                 inst.image.destroy()
                 inst.destroy()
-                # pylint: disable=consider-iterating-dictionary
-                if inst.name in self.vms.keys():
+                if inst.name in self.vms:
                     del self.vms[inst.name]
 
     def removeall(self):


### PR DESCRIPTION
TD guest kernel only allow limited device/driver via device filter approach
due to security consideration. So

1. By default, tdx_disable_filter should be removed from guest kernel command
2. vsock in guest is disabled by default via filter, so if want get TDREPORT
   via vsock approach instead of from TDVMCALL, tdx_disable_filter is a
   workaround to use.
3. Remove unnecessary disabling for pylint.

Signed-off-by: Lu Ken <ken.lu@intel.com>