### PR TITLE
Not enable SSH port forward by default

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -197,7 +197,6 @@ class VMMLibvirt(VMMBase):
             xmlobj.kernel = self.vminst.kernel
             xmlobj.cmdline = str(self.vminst.cmdline)
 
-        xmlobj.enable_ssh_forward_port(self.vminst.ssh_forward_port)
         return xmlobj
 
     def _connect_virt(self):    # pylint: disable=no-self-use


### PR DESCRIPTION
SSH port forward is used to map guest SSH port to local host without
bridge networking. But this approach might cause unpredicted boot
duration. So disable it by default for fast boot.

Signed-off-by: Lu Ken <ken.lu@intel.com>