### PR TITLE
CI: fix the code scan issue of ignoring pylint errors

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,7 +19,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install pylint
           pip install -r utils/pycloudstack/requirements.txt
+          pip install -r utils/pytdxmeasure/requirements.txt
+          pip install -r tests/requirements.txt
       - name: Analysing the code with pylint
         run: |
           set -ex
-          find . -name '*.py' -exec pylint {} \;
+          export PYTHONPATH=utils/pycloudstack:utils/pytdxmeasure
+          find . -name *.py -print0 | xargs -n 1 -0 pylint

--- a/utils/pycloudstack/requirements.txt
+++ b/utils/pycloudstack/requirements.txt
@@ -3,3 +3,4 @@ py-cpuinfo>=7.0.0
 pyyaml>=5.4.1
 libvirt-python
 wheel
+docker


### PR DESCRIPTION
1. When pylint found any known issues on python module, CI should
   report the error to committer for fix before review. But current CI
   script in github action will ignore issues.
2. Before pylint scan the python module, the CI need install all
   dependencies and configure the PYTHONPATH well.

Signed-off-by: Lu Ken <ken.lu@intel.com>