### PR TITLE
build/centos-stream-8/pkg-builder: add --nobest to update command

### DIFF
--- a/build/centos-stream-8/pkg-builder/Dockerfile
+++ b/build/centos-stream-8/pkg-builder/Dockerfile
@@ -7,7 +7,7 @@ ARG buildreqs="bzip2 coreutils cpio diffutils \
 
 COPY aliyun.repo /etc/yum.repos.d/
 
-RUN dnf -y --setopt="tsflags=nodocs" update --allowerasing && \
+RUN dnf -y --setopt="tsflags=nodocs" update --nobest --allowerasing && \
     dnf -y --setopt="tsflags=nodocs" install --allowerasing $buildreqs && \
     dnf clean all && rm -rf /var/cache/yum/
 


### PR DESCRIPTION
Updating the container currently tries to remove a protected package.

Add --nobest so that the problematic packages are not updated.

Signed-off-by: California Sullivan <california.l.sullivan@intel.com>