### PR TITLE
guest-image: fix wrong path for rhel

### DIFF
--- a/build/centos-stream-8/guest-image/tdx-guest-stack.sh
+++ b/build/centos-stream-8/guest-image/tdx-guest-stack.sh
@@ -30,7 +30,7 @@ ARGS+=" --copy-in config/srv_guest.repo:/etc/yum.repos.d/"
 # Install TDX guest packages
 GRUB="intel-mvp-tdx-guest-grub2-efi-x64 intel-mvp-tdx-guest-grub2-pc"
 SHIM="intel-mvp-tdx-guest-shim"
-KERNEL="intel-mvp-tdx-guest-kernel"
+KERNEL="intel-mvp-spr-kernel-guest"
 REPO="srv_guest"
 ARGS+=" --run-command 'dnf install ${GRUB} ${SHIM} ${KERNEL} -y --repo ${REPO}'"
 

--- a/build/rhel-8/guest-image/create-efi-img.sh
+++ b/build/rhel-8/guest-image/create-efi-img.sh
@@ -27,7 +27,7 @@ eval virt-install \
     --ram 16384 \
     --vcpus 8 \
     --os-type linux \
-    --os-variant rhel8 \
+    --os-variant rhel8.5 \
     --network bridge=virbr0 \
     --nographics \
     --disk=${IMAGE_NAME},bus=virtio,format=qcow2,size=${IMAGE_SIZE} \

--- a/build/rhel-8/guest-image/tdx-guest-stack.sh
+++ b/build/rhel-8/guest-image/tdx-guest-stack.sh
@@ -32,14 +32,14 @@ ARGS+=" --copy-in config/srv_guest.repo:/etc/yum.repos.d/"
 # Install TDX guest packages
 GRUB="intel-mvp-tdx-guest-grub2-efi-x64 intel-mvp-tdx-guest-grub2-pc"
 SHIM="intel-mvp-tdx-guest-shim"
-KERNEL="intel-mvp-tdx-guest-kernel"
+KERNEL="intel-mvp-spr-kernel-guest"
 REPO="srv_guest"
 ARGS+=" --run-command 'dnf install ${GRUB} ${SHIM} ${KERNEL} -y --repo ${REPO}'"
 
 # Setup grub
 ARGS+=" --copy-in config/grub:/etc/default/"
-ARGS+=" --run-command 'grub2-editenv /boot/efi/EFI/centos/grubenv create'"
-ARGS+=" --run-command 'grub2-mkconfig -o /boot/efi/EFI/centos/grub.cfg'"
+ARGS+=" --run-command 'grub2-editenv /boot/efi/EFI/redhat/grubenv create'"
+ARGS+=" --run-command 'grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg'"
 
 echo "${ARGS}"
 eval virt-customize "${ARGS}"


### PR DESCRIPTION
Correct EFI boot path to /boot/efi/EFI/redhat/ for rhel guest image

Signed-off-by: jialeie <jialei.feng@intel.com>