### PR TITLE
build: remove root command

### DIFF
--- a/build/centos-stream-8/build-repo.sh
+++ b/build/centos-stream-8/build-repo.sh
@@ -66,8 +66,8 @@ finalize() {
 # Check whether createrepo tool installed
 if ! command -v "createrepo"
 then
-    echo "Did not find createrepo package, install..."
-    dnf install createrepo -y
+    echo "Did not find createrepo package, please install it by dnf install createrepo"
+    exit 1
 fi
 
 # Build host repo

--- a/build/rhel-8/build-repo.sh
+++ b/build/rhel-8/build-repo.sh
@@ -66,8 +66,8 @@ finalize() {
 # Check whether createrepo tool installed
 if ! command -v "createrepo"
 then
-    echo "Did not find createrepo package, install..."
-    dnf install createrepo -y
+    echo "Did not find createrepo package, please install it by dnf install createrepo"
+    exit 1
 fi
 
 # Build host repo


### PR DESCRIPTION
It is recommended that all commands be run in non-root,
except for dnf builddep in each build script.

Signed-off-by: Feng, Jialei <jialei.feng@intel.com>