### PR TITLE
README.md: Add the TDX SEAM module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ below diagram:
 | -- | -- | -- |
 | [SPR Kernel](https://github.com/intel/linux-kernel-dcp) | Host + Guest | Linux kernel for Sapphire Rapids platform |
 | [SPR Qemu-KVM](https://github.com/intel/qemu-dcp) | Host | Qemu VMM for Sapphire Rapids platform |
+| [TDX SEAM Module](https://github.com/intel/tdx-module/) | Host | TDX Secure Arbitration Module |
 | [TDX Libvirt](https://github.com/intel/libvirt-tdx) | Host | The modified libvirt to create TDX guest domain via Qemu |
 | [TDVF](https://github.com/tianocore/edk2-staging/tree/TDVF) | Host | The modified OVMF(Open Source Virtual Firmware) to support TDX guest boot like page accept, TDX measurement |
 | [TDX Grub2](https://github.com/intel/grub-tdx) | Guest | The modified grub for guest VM to support TDX measurement |
@@ -77,6 +78,11 @@ Finally, install packages as follows:
 ```
 sudo dnf install intel-mvp-spr-kernel intel-mvp-tdx-tdvf intel-mvp-spr-qemu-kvm intel-mvp-tdx-libvirt
 ```
+
+_NOTE_: Please get separated RPM for signed build `TDX SEAM Module` and install via
+`sudo dnf install intel-mvp-tdx-module-spr`. After installation, please reboot
+machine with `tdx_host=on` in host kernel command via grub menu. Finally, please
+[verify TDX host](./doc/verify_tdx_host.md).
 
 ### 3.2 Prepare TDX Guest Image
 


### PR DESCRIPTION
1. TDX SEAM module is already opened source at https://github.com/intel/tdx-module/.
2. Add steps to install signed build TDX module.
3. Add reference to verify the TDX host.

Signed-off-by: Lu Ken <ken.lu@intel.com>