### PR TITLE
vmparam.py: Use VMSpec replace CPUTopology and memory size

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -112,15 +112,9 @@ class VMMBase:
         """
         raise NotImplementedError
 
-    def update_cpu_topology(self, cpu_topology):
+    def update_vmspec(self, new_vmspec):
         """
-        Update cpu topology
-        """
-        raise NotImplementedError
-
-    def update_memsize(self, memsize):
-        """
-        Update memory size of vm
+        Update VM spec include CPU topology and memory size
         """
         raise NotImplementedError
 
@@ -150,13 +144,13 @@ class VMMLibvirt(VMMBase):
         xmlobj = VirtXml.clone(
             self._TEMPLATE[self.vminst.vmtype],
             self.vminst.name)
-        xmlobj.memory = int(self.vminst.memsize * 1024 * 1024)
+        xmlobj.memory = self.vminst.vmspec.memsize
         xmlobj.uuid = self.vminst.vmid
         xmlobj.imagefile = self.vminst.image.filepath
-        xmlobj.vcpu = self.vminst.cpu_topology.vcpus
-        xmlobj.sockets = self.vminst.cpu_topology.sockets
-        xmlobj.cores = self.vminst.cpu_topology.cores
-        xmlobj.threads = self.vminst.cpu_topology.threads
+        xmlobj.vcpu = self.vminst.vmspec.vcpus
+        xmlobj.sockets = self.vminst.vmspec.sockets
+        xmlobj.cores = self.vminst.vmspec.cores
+        xmlobj.threads = self.vminst.vmspec.threads
 
         var_filename = "OVMF_VARS." + xmlobj.uuid + ".fd"
         var_fullpath = os.path.join(tempfile.gettempdir(), var_filename)
@@ -389,15 +383,9 @@ class VMMLibvirt(VMMBase):
         """
         raise NotImplementedError
 
-    def update_cpu_topology(self, cpu_topology):
+    def update_vmspec(self, new_vmspec):
         """
-        Update cpu topology
-        """
-        raise NotImplementedError
-
-    def update_memsize(self, memsize):
-        """
-        Update memory size of vm
+        Update VM spec include CPU topology and memory size
         """
         raise NotImplementedError
 

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -28,13 +28,6 @@ VM_STATE_SHUTDOWN_IN_PROGRESS = "shutting down"
 
 BOOT_TIMEOUT = 180
 
-# MODEL array:  #vcpus  #sockets #cores #threads
-MODEL_BASE = {"vcpus": 1, "sockets": 1, "cores": 1, "threads": 1, "memsize": 1}
-MODEL_LARGE = {"vcpus": 8, "sockets": 1,
-               "cores": 4, "threads": 2, "memsize": 32}
-MODEL_NUMA = {"vcpus": 16, "sockets": 2,
-              "cores": 4, "threads": 2, "memsize": 32}
-
 HUGEPAGES_1G = "1G"
 HUGEPAGES_2M = "2M"
 
@@ -130,15 +123,18 @@ class KernelCmdline:
         self._cmdline = retval
 
 
-class CPUTopology:
+class VMSpec:
     """
     CPU Topology parameter for VM configure.
     """
 
-    def __init__(self, sockets=1, cores=1, threads=1):
+    def __init__(self, sockets=1, cores=4, threads=1, memsize=None):
         self.sockets = sockets
         self.cores = cores
         self.threads = threads
+        self.memsize = memsize
+        if memsize is None:
+            self.memsize = self.vcpus * 4 * 1024 * 1024
 
     @property
     def vcpus(self):
@@ -152,3 +148,24 @@ class CPUTopology:
         Is the NUMA enabled
         """
         return self.sockets > 1
+
+    @staticmethod
+    def model_base():
+        """
+        Generate base model
+        """
+        return VMSpec(sockets=1, cores = 4, threads=1, memsize=16*1024*1024)
+
+    @staticmethod
+    def model_large():
+        """
+        Generate large model
+        """
+        return VMSpec(sockets=1, cores=8, threads=1, memsize=32*1024*1024)
+
+    @staticmethod
+    def model_numa():
+        """
+        Generate numa model
+        """
+        return VMSpec(sockets=2, cores=4, threads=1, memsize=32*1024*1024)


### PR DESCRIPTION
Originally, use CPUTopology for cores, threads, sockets and vcpus and memory
size for whole VM spec, it bring lots of parameter and overide relationship.
To simplify the design, create a new VMSpec = CPUTopoloy + memsize.

With this new design,
- MODEL_LARGE => VMSpec.model_large()
- MODEL_BASE  => VMSpec.model_base()
- MODEL_NUMA  => VMSpec.model_numa()

Signed-off-by: Lu Ken <ken.lu@intel.com>