### PR TITLE
build-repo: move guest kernel packages if they exist

### DIFF
--- a/build/centos-stream-8/build-repo.sh
+++ b/build/centos-stream-8/build-repo.sh
@@ -47,7 +47,9 @@ move_packages() {
     dest=$2
 
     for package in "${packages[@]}"; do
-        mv repo/"${begin}"/x86_64/"${package}"* repo/"${dest}"/x86_64/
+        if ls repo/"${begin}"/x86_64/"${package}"* >/dev/null 2>&1; then
+            mv repo/"${begin}"/x86_64/"${package}"* repo/"${dest}"/x86_64/
+        fi
     done
 }
 

--- a/build/centos-stream-8/guest-image/tdx-guest-stack.sh
+++ b/build/centos-stream-8/guest-image/tdx-guest-stack.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+export LIBGUESTFS_BACKEND=direct
+
 CURR_DIR=$(readlink -f "$(dirname "$0")")
 REPO_DIR="../repo/guest/"
 IMAGE="td-guest-c8s.qcow2"

--- a/build/rhel-8/build-repo.sh
+++ b/build/rhel-8/build-repo.sh
@@ -47,7 +47,9 @@ move_packages() {
     dest=$2
 
     for package in "${packages[@]}"; do
-        mv repo/"${begin}"/x86_64/"${package}"* repo/"${dest}"/x86_64/
+        if ls repo/"${begin}"/x86_64/"${package}"* >/dev/null 2>&1; then
+            mv repo/"${begin}"/x86_64/"${package}"* repo/"${dest}"/x86_64/
+        fi
     done
 }
 


### PR DESCRIPTION
When running build-repo.sh again, e.g. customize qemu and then rebuild repo,
most likely guest kernel packages have already been moved.

Signed-off-by: Feng, Jialei <jialei.feng@intel.com>