### PR TITLE
utils/pycloudstack: update and customize SGX EPC config for each VM

### DIFF
--- a/utils/pycloudstack/pycloudstack/templates/sgx-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/sgx-base.xml
@@ -12,7 +12,8 @@
     <topology sockets='1' cores='4' threads='4'/>
   </cpu>
   <os>
-    <type arch='x86_64' machine='pc-q35-5.1'>hvm</type>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <loader>/usr/share/qemu-kvm/bios.bin</loader>
     <boot dev='hd'/>
   </os>
   <features>
@@ -39,24 +40,17 @@
       <driver name='qemu' type='qcow2'/>
       <source file='REPLACEME_IMAGE' />
       <target dev='vda' bus='virtio'/>
-      <address type='pci' domain='0x0000' bus='0x04' slot='0x00' function='0x0'/>
     </disk>
     <console type='pty'>
       <target type='virtio' port='0'/>
     </console>
     <interface type='bridge'>
-      <mac address='52:54:00:c5:9e:eb' />
-      <source bridge='br0'/>
+      <source bridge='virbr0'/>
       <model type='virtio'/>
-      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
     </interface>
   </devices>
   <qemu:commandline>
     <qemu:arg value='-cpu'/>
-    <qemu:arg value='host,host-phys-bits,+sgx,+sgx-debug,+sgx-exinfo,+sgx-kss,+sgx-mode64,+sgx-provisionkey,+sgx-tokenkey,+sgx1,+sgx2,+sgxlc'/>
-    <qemu:arg value='-object'/>
-    <qemu:arg value='memory-backend-epc,id=mem1,size=512M,prealloc'/>
-    <qemu:arg value='-sgx-epc'/>
-    <qemu:arg value='id=epc1,memdev=mem1'/>
+    <qemu:arg value='host'/>
   </qemu:commandline>
 </domain>

--- a/utils/pycloudstack/pycloudstack/virtxml.py
+++ b/utils/pycloudstack/pycloudstack/virtxml.py
@@ -567,6 +567,40 @@ class VirtXml:
             allow_multi_same_leaf=True)
         self.save()
 
+    def set_epc_params(self, epc_param):
+        """
+        Set SGX EPC parameters, for example:
+            -object memory-backend-epc,id=mem1,size=64M,prealloc=on \
+            -object memory-backend-epc,id=mem2,size=28M \
+            -M sgx-epc.0.memdev=mem1,sgx-epc.0.node=0, \
+               sgx-epc.1.memdev=mem2,sgx-epc.1.node=1
+        """
+        sgx_epc = ""
+        num = 0
+        for section in epc_param:
+            num += 1
+            prealloc = ",prealloc=on" if section['prealloc'] else ""
+            self._add_new_element(
+                [f"{QEMUS_NS}commandline", f"{QEMUS_NS}arg"],
+                {"value": "-object"},
+                allow_multi_same_leaf=True)
+            self._add_new_element(
+                [f"{QEMUS_NS}commandline", f"{QEMUS_NS}arg"],
+                {"value": f"memory-backend-epc,id=mem{num},size={section['size']}"
+                f"{prealloc}"}, allow_multi_same_leaf=True)
+            sgx_epc += f"sgx-epc.{num - 1}.memdev=mem{num}"
+            sgx_epc += f",sgx-epc.{num - 1}.node={section['node']},"
+
+        self._add_new_element(
+                [f"{QEMUS_NS}commandline", f"{QEMUS_NS}arg"],
+                {"value": "-M"},
+                allow_multi_same_leaf=True)
+        self._add_new_element(
+                [f"{QEMUS_NS}commandline", f"{QEMUS_NS}arg"],
+                {"value": f"{sgx_epc[:-1]}"},
+                allow_multi_same_leaf=True)
+        self.save()
+
     def set_vsock(self, cid):
         """
         Enable and set cid for vsock

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -175,6 +175,7 @@ class VMMLibvirt(VMMBase):
             xmlobj.set_cpu_params(
                 "host,host-phys-bits,+sgx,+sgx-debug,+sgx-exinfo,"
                 "+sgx-kss,+sgx-mode64,+sgx-provisionkey,+sgx-tokenkey,+sgx1,+sgx2,+sgxlc")
+            xmlobj.set_epc_params(self.vminst.vmspec.epc)
         elif self.vminst.vmtype == VM_TYPE_TD:
             xmlobj.loader = BIOS_OVMF_CODE
             xmlobj.nvram = var_fullpath

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -169,3 +169,24 @@ class VMSpec:
         Generate numa model
         """
         return VMSpec(sockets=2, cores=4, threads=1, memsize=32*1024*1024)
+
+
+class SGXVMSpec(VMSpec):
+    """
+    SGX specific configurations
+    """
+
+    def __init__(self, sockets=1, cores=4, threads=1, memsize=None, epc=None):
+        """
+        The EPC configuration should be like:
+            -object memory-backend-epc,id=mem1,size=64M,prealloc=on \
+            -object memory-backend-epc,id=mem2,size=28M \
+            -M sgx-epc.0.memdev=mem1,sgx-epc.0.node=0, \
+               sgx-epc.1.memdev=mem2,sgx-epc.1.node=1
+        so define epc parameter as a list, like:
+            epc = [{'size': '64M', 'prealloc': True, 'node': 0},
+                   {'size': '28M', 'prealloc': False, 'node': 1}]
+        """
+        super().__init__(sockets, cores, threads, memsize)
+        assert epc is not None and len(epc) > 0
+        self.epc = epc


### PR DESCRIPTION
1. sgx-base template cleanup
2. To fit latest SGX EPC Qemu command lines:
```xml
-object memory-backend-epc,id=mem1,size=64M,prealloc=on \
-object memory-backend-epc,id=mem2,size=28M \
-M sgx-epc.0.memdev=mem1,sgx-epc.0.node=0, \
   sgx-epc.1.memdev=mem2,sgx-epc.1.node=1
```
add function `set_epc_params` and class `SGXVMSpec` to customize config for each VM
usage:
```python
epc = [{'size': '32G', 'prealloc': True, 'node': 0}]
Spec = SGXVMSpec(sockets=1, cores=8, threads=1, memsize=(64 * 1024 * 1024), epc=epc)
```

Signed-off-by: Dong Xiaocheng <xiaocheng.dong@intel.com>