### PR TITLE
vmguest.py and vmm.py - support virsh shutdown mode

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -246,13 +246,16 @@ class VMGuest:
         assert self.vmm is not None
         self.vmm.resume()
 
-    def shutdown(self):
+    def shutdown(self, mode=None):
         """
         Shutdown a VM
         """
         LOG.debug("+ Shutdown guest %s", self.name)
         assert self.vmm is not None
-        self.vmm.shutdown()
+        if mode is None:
+            self.vmm.shutdown()
+        else:
+            self.vmm.shutdown(mode)
 
     def destroy(self, delete_image=False):
         """


### PR DESCRIPTION
1. Support specific mode in libvirt shutdown. It supports mode "default"/"acpi"/"agent" for now.
2. Catch exception of DomainUUID cannot be found if the VM has been explicitly destroyed before teardown.
Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>