### PR TITLE
Add console log for VMs

### DIFF
--- a/utils/pycloudstack/pycloudstack/templates/legacy-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/legacy-base.xml
@@ -40,6 +40,7 @@
       <target dev='vda' bus='virtio'/>
     </disk>
     <console type='pty'>
+      <log file='REPLACEME_LOG'/>
       <target type='virtio' port='0'/>
     </console>
     <interface type='bridge'>

--- a/utils/pycloudstack/pycloudstack/templates/ovmf-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/ovmf-base.xml
@@ -41,6 +41,7 @@
       <target dev='vda' bus='virtio'/>
     </disk>
     <console type='pty'>
+      <log file='REPLACEME_LOG'/>
       <target type='virtio' port='0'/>
     </console>
     <interface type='bridge'>

--- a/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
@@ -42,6 +42,7 @@
       <target dev='vda' bus='virtio'/>
     </disk>
     <console type='pty'>
+      <log file='REPLACEME_LOG'/>
       <target type='virtio' port='0'/>
     </console>
     <interface type='bridge'>

--- a/utils/pycloudstack/pycloudstack/virtxml.py
+++ b/utils/pycloudstack/pycloudstack/virtxml.py
@@ -53,6 +53,7 @@ class VirtXml:
         self._memory = None
         self._vcpu = None
         self._imagefile = None
+        self._logfile = None
         self._filepath = None
         self._sockets = None
         self._cores = None
@@ -278,6 +279,22 @@ class VirtXml:
         self.save()
 
     @property
+    def logfile(self):
+        """
+        <domain>/<devices>/<console>/<log> - log file field in xml
+        """
+        return self._logfile
+
+    @logfile.setter
+    def logfile(self, new_file):
+        if self._logfile == new_file:
+            return
+        _, log_dom = self._find_single_element(["devices", "console", "log"])
+        log_dom.set("file", new_file)
+        self._logfile = new_file
+        self.save()
+
+    @property
     def filepath(self):
         """
         File path for virt XML
@@ -297,6 +314,7 @@ class VirtXml:
         LOG.debug("|  * cmdline : %s", self._cmdline)
         LOG.debug("|  * loader  : %s", self._loader)
         LOG.debug("|  * nvram   : %s", self._nvram)
+        LOG.debug("|  * log     : %s", self._logfile)
         LOG.debug("-----------------------------------------------------------")
 
         if self._tree is not None and dump_xml:

--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -254,7 +254,7 @@ class VMGuest:
         assert self.vmm is not None
         self.vmm.shutdown()
 
-    def destroy(self, delete_image=False):
+    def destroy(self, delete_image=False, delete_log=False):
         """
         Destroy VM Guest
         """
@@ -262,6 +262,8 @@ class VMGuest:
         self.vmm.destroy()
         if delete_image:
             self.image.destroy()
+        if delete_log:
+            self.vmm.delete_log()
 
     def reboot(self):
         """
@@ -374,6 +376,7 @@ class VMGuestFactory:
         if not self._keep_issue_vm:
             inst.image.destroy()
             inst.destroy()
+            inst.delete_log()
             if inst.name in self.vms:
                 del self.vms[inst.name]
         else:
@@ -390,12 +393,12 @@ class VMGuestFactory:
         destroyed_vms = []
         if not self._keep_issue_vm:
             for item in self.vms.values():
-                item.destroy(True)
+                item.destroy(delete_image=True, delete_log=True)
             self.vms.clear()
         else:
             for item in self.vms.values():
                 if item.state() is VM_STATE_RUNNING and not item.keep:
-                    item.destroy(True)
+                    item.destroy(delete_image=True, delete_log=True)
                     destroyed_vms.append(item.name)
             for vm_name in destroyed_vms:
                 del self.vms[vm_name]

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -147,6 +147,7 @@ class VMMLibvirt(VMMBase):
         xmlobj.memory = self.vminst.vmspec.memsize
         xmlobj.uuid = self.vminst.vmid
         xmlobj.imagefile = self.vminst.image.filepath
+        xmlobj.logfile = "/tmp/" + self.vminst.name + ".log"
         xmlobj.vcpu = self.vminst.vmspec.vcpus
         xmlobj.sockets = self.vminst.vmspec.sockets
         xmlobj.cores = self.vminst.vmspec.cores
@@ -258,6 +259,17 @@ class VMMLibvirt(VMMBase):
                 os.remove(self._xml.filepath)
             except (OSError, IOError):
                 LOG.warning("Fail to delete Virt XML %s", self._xml.filepath)
+
+    def delete_log(self):
+        """
+        Delete VM log file.
+        """
+        if os.path.exists(self._xml.logfile):
+            try:
+                os.remove(self._xml.logfile)
+                LOG.debug("Delete VM log file %s", self._xml.logfile)
+            except (OSError, IOError):
+                LOG.warning("Fail to delete VM log file %s", self._xml.logfile)
 
     def start(self):
         """

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -14,7 +14,7 @@ BOOT_TYPE_GRUB = "grub"
 # Also, hvc0 is the default console for TD VM, ttyS0 will be filtered
 # due to security concern.
 #
-DEFAULT_CMDLINE = "root=/dev/vda3 rw selinux=0 console=hvc0 "
+DEFAULT_CMDLINE = "root=/dev/vda3 rw selinux=0 console=hvc0 earlyprintk console=tty0"
 
 # Installed from the package of intel-mvp-qemu-kvm
 BIOS_OVMF_CODE = "/usr/share/qemu/OVMF_CODE.fd"


### PR DESCRIPTION
With this commit, it can collect VM boot console log for debug purpose. VM log will be kept for unhealthy VMs.
1. virtxml.py - add methods to parse and set logfile
2. vmguest.py - add method to delete vm log file, keep log file for unhealthy VM
3. vmm.py - add method to delete vm log file
4. vmparam.py - add kernel cmdline to catch kernel log
5. update VM xml template to generate VM log

Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>