### PR TITLE
ignore build paths with .git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.qcow2
 vmlinuz
 *.fd
+
+build/centos-stream-8/intel-mvp-spr-kernel/linux-spr-kernel/
+build/centos-stream-8/intel-mvp-tdx-guest-shim/shim-15.4/
+build/centos-stream-8/intel-mvp-tdx-libvirt/libvirt/
+build/centos-stream-8/intel-mvp-tdx-tdvf/edk2-staging/


### PR DESCRIPTION
These paths can not be removed with `git clean -dfx` as they contain `.git` 