### PR TITLE
start-qemu.sh: remove "tdx_disable_filter" requirement

### DIFF
--- a/start-qemu.sh
+++ b/start-qemu.sh
@@ -183,10 +183,6 @@ process_args() {
         case ${QUOTE_TYPE} in
             "tdvmcall") ;;
             "vsock")
-                # vsock is filtered by guest kernel by default due to security consideration
-                # so if using vsock to get TDREPORT, tdx_disable_filter is required as a
-                # workaround. It is recommend to use tdvmcall approach instead of vsock
-                KERNEL_CMD_TD+=" tdx_disable_filter"
                 USE_VSOCK=true
                 ;;
             *)


### PR DESCRIPTION
When using vsock to get TDREPORT, passing "tdx_disable_filter" on the kernel
command line used to be required as a workaround. However, this workaround also
compromised the security.

Disabling the filter is no longer needed for recent kernels.
Vsock driver has been audited and added to the list of allowed TDX devices.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>