### PR TITLE
vmguest.py: remove delete_log() to fix the error

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -379,7 +379,6 @@ class VMGuestFactory:
         if not self._keep_issue_vm:
             inst.image.destroy()
             inst.destroy()
-            inst.delete_log()
             if inst.name in self.vms:
                 del self.vms[inst.name]
         else:


### PR DESCRIPTION
The last revision added a method to delete the vm log file but forgot to remove the unnecessary code. This update is to remove this line to fix the bug.