### PR TITLE
ubuntu 22.04: fix shim postinstall error in guest VM using virtio-blk

### DIFF
--- a/build/ubuntu-22.04/intel-mvp-tdx-guest-shim/debian/shim.postinst
+++ b/build/ubuntu-22.04/intel-mvp-tdx-guest-shim/debian/shim.postinst
@@ -70,7 +70,10 @@ case $1 in
 	# want to trigger the install code just by installing the package,
 	# normally the installer installs grub itself first.
 	if [ -e /boot/grub/${grubarch}/core.efi ]; then
-	    /usr/lib/grub/grub-multi-install --target=${grubarch} --auto-nvram
+	    #/usr/lib/grub/grub-multi-install --target=${grubarch} --auto-nvram
+	    cp /usr/lib/shim/fbx64.efi /boot/efi/EFI/BOOT/
+	    cp /usr/lib/shim/mmx64.efi /boot/efi/EFI/BOOT/
+	    cp /usr/lib/shim/shimx64.efi /boot/efi/EFI/BOOT/BOOTX64.EFI
 	    cp /usr/lib/shim/BOOTX64.CSV /boot/efi/EFI/ubuntu/
 	    cp /usr/lib/shim/mmx64.efi /boot/efi/EFI/ubuntu/
 	    cp /usr/lib/shim/shimx64.efi /boot/efi/EFI/ubuntu/


### PR DESCRIPTION
There is no /dev/disk/by-id in guest VM using virtio-blk driver. Error message:
Unknown device "/dev/disk/by-id/*": No such file or directory

Signed-off-by: jialeie <jialei.feng@intel.com>