### PR TITLE
ubuntu 22.04: update kernel to SPR-BKC-PC-v8.5

### DIFF
--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/build.sh
@@ -6,7 +6,7 @@ CURR_DIR=$(dirname "$(readlink -f "$0")")
 UPSTREAM_VERSION="5.15"
 DOWNSTREAM_GIT_URI="https://github.com/intel/linux-kernel-dcp.git"
 
-DOWNSTREAM_TAG="SPR-BKC-PC-v7.7"
+DOWNSTREAM_TAG="SPR-BKC-PC-v8.5"
 PACKAGE="mvp-linux-kernel"
 
 get_source() {

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/debian.master/changelog
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/debian.master/changelog
@@ -1,3 +1,9 @@
+linux (5.15.0-mvp3v8-5.spr) jammy; urgency=medium
+
+  * jammy/linux: 5.15.0-mvp3v8-5.spr -proposed tracker (LP: #1990000)
+
+ -- Jialei Feng <jialei.feng@intel.com>  Thu, 2 Jun 2022 15:12:34 +0800
+
 linux (5.15.0-mvp3v7-7.spr) jammy; urgency=medium
 
   * jammy/linux: 5.15.0-mvp3v7-7.spr -proposed tracker (LP: #1990000)

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/debian/changelog
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/debian/changelog
@@ -1,3 +1,9 @@
+linux (5.15.0-mvp3v8-5.spr) jammy; urgency=medium
+
+  * jammy/linux: 5.15.0-mvp3v8-5.spr -proposed tracker (LP: #1990000)
+
+ -- Jialei Feng <jialei.feng@intel.com>  Thu, 2 Jun 2022 15:12:34 +0800
+
 linux (5.15.0-mvp3v7-7.spr) jammy; urgency=medium
 
   * jammy/linux: 5.15.0-mvp3v7-7.spr -proposed tracker (LP: #1990000)


### PR DESCRIPTION
Signed-off-by: jialeie <jialei.feng@intel.com>