### PR TITLE
ubuntu 22.04: update to SPR-BKC-PC-v8.8

### DIFF
--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/debian.master/changelog
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/debian.master/changelog
@@ -1,3 +1,9 @@
+linux (5.15.0-mvp4v8+8.spr) jammy; urgency=medium
+
+  * jammy/linux: 5.15.0-mvp4v8+8.spr -proposed tracker (LP: #1990000)
+
+ -- Jialei Feng <jialei.feng@intel.com>  Thu, 15 Jun 2022 11:08:00 +0800
+
 linux (5.15.0-mvp3v8-5.spr) jammy; urgency=medium
 
   * jammy/linux: 5.15.0-mvp3v8-5.spr -proposed tracker (LP: #1990000)

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/debian/changelog
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/debian/changelog
@@ -1,3 +1,9 @@
+linux (5.15.0-mvp4v8+8.spr) jammy; urgency=medium
+
+  * jammy/linux: 5.15.0-mvp4v8+8.spr -proposed tracker (LP: #1990000)
+
+ -- Jialei Feng <jialei.feng@intel.com>  Thu, 15 Jun 2022 11:08:00 +0800
+
 linux (5.15.0-mvp3v8-5.spr) jammy; urgency=medium
 
   * jammy/linux: 5.15.0-mvp3v8-5.spr -proposed tracker (LP: #1990000)

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/0001-X86-VIRTEXT-Fix-false-alarm-of-vmptrst-failure-in-ra.patch
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/0001-X86-VIRTEXT-Fix-false-alarm-of-vmptrst-failure-in-ra.patch
@@ -1,0 +1,79 @@
+From 1fca82c29b769a4d16dd10645a88ffc99a4e49e1 Mon Sep 17 00:00:00 2001
+From: Yuan Yao <yuan.yao@intel.com>
+Date: Tue, 14 Jun 2022 08:53:50 +0800
+Subject: [BKC][PATCH v1 1/1] X86: VIRTEXT: Fix false alarm of vmptrst failure
+ in raw_vmcs_store()
+
+Use "+r" constraint modifier for variable fault in inline ASM.
+
+fault is used as input/output for the inline ASM statements, use "=r"
+makes AS treating fault as output only, which leads to panic because
+no guarantee of the register which maps to fault is 0 while the
+raw_vmcs_store() is called.
+
+Also remove all checkings to the EFLAGS.ZF and CF because
+only 2 scenarios vmptrst can meet: Successfully or #UD/#GP/#SS/#PF.
+rmptrst saves -1 to the memory operand if no current vmcs is loaded.
+
+kernel BUG at arch/x86/kernel/cpu/virtext.c:42!
+RIP: 0010:virt_spurious_fault+0x1c/0x30
+Call Trace:
+ raw_vmcs_store+0x60/0x90
+ pseamldr_seamcall.constprop.0+0x41/0x190
+ seamldr_info+0x1d/0x50
+ p_seamldr_get_info+0x157/0x21d
+ tdx_host_early_init+0x92/0x106
+ do_one_initcall+0x46/0x1d0
+ kernel_init_freeable+0x133/0x1b1
+ kernel_init+0x1b/0x150
+ ret_from_fork+0x1f/0x30
+
+Cc: Gao Chao <chao.gao@intel.com>
+Fixes: 796a0442e001 ("x86/cpu/virtext: Introduce raw_vmcs_store")
+Signed-off-by: Yuan Yao <yuan.yao@intel.com>
+
+---
+
+Notes: It's BKC only issue now and send out for reviewing before
+request to merge by fenghua. Because upstream doesn't support in
+kernel TDX module loading.
+
+
+arch/x86/kernel/cpu/virtext.c | 11 +++--------
+ 1 file changed, 3 insertions(+), 8 deletions(-)
+
+diff --git a/arch/x86/kernel/cpu/virtext.c b/arch/x86/kernel/cpu/virtext.c
+index 0cb6c039f1b4..cc567dae4c26 100644
+--- a/arch/x86/kernel/cpu/virtext.c
++++ b/arch/x86/kernel/cpu/virtext.c
+@@ -63,25 +63,20 @@ EXPORT_SYMBOL_GPL(vmptrld_error);
+
+ int raw_vmcs_store(u64 *vmcs_pa)
+ {
+-	bool ret;
+ 	bool fault = 0;
+
+-	asm volatile("1: vmptrst %1\n\t"
++	asm volatile("1: vmptrst %0\n\t"
+ 		     "2:\n\t"
+ 		     ".pushsection .fixup, \"ax\"\n\t"
+-		     "3: mov $1, %2\n\t"
++		     "3: mov $1, %1\n\t"
+ 		     "jmp 2b\n\t"
+ 		     ".popsection\n\t"
+ 		     _ASM_EXTABLE(1b, 3b)
+-		     CC_SET(na)
+-		     : CC_OUT(na) (ret), "=m" (*vmcs_pa), "=r" (fault) : :);
++		     : "=m" (*vmcs_pa), "+r" (fault) : :);
+
+ 	if (fault) {
+ 		virt_spurious_fault();
+ 		return -EIO;
+-	} else if (ret) {
+-		vmx_insn_failed("vmptrst failed: %p\n", vmcs_pa);
+-		return -EIO;
+ 	}
+
+ 	return 0;
+--
+2.27.0

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/0001-efi-x86-stub-fix-absolute-symbol-reference.patch
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/0001-efi-x86-stub-fix-absolute-symbol-reference.patch
@@ -1,0 +1,42 @@
+From 1921bea682255dc62a2c6f9a8d2158438cffe517 Mon Sep 17 00:00:00 2001
+From: Elena Reshetova <elena.reshetova@intel.com>
+Date: Tue, 14 Jun 2022 11:59:52 +0300
+Subject: [PATCH] efi/x86-stub: fix absolute symbol reference
+
+Fixes the following build error on ubuntu 22.04:
+
+0000000000000000 R_X86_64_64 .text+0x00000000000003b9
+0000000000000000 R_X86_64_64 .text+0x00000000000003b9
+drivers/firmware/efi/libstub/x86-stub.stub.o: absolute symbol
+references not allowed in the EFI stub
+make[6]: *** [/home/elena/tdx/tdx-tools/build/ubuntu-22.04/
+intel-mvp-spr-kernel/mvp-linux-kernel-5.15/drivers/firmware/
+efi/libstub/Makefile:129:
+drivers/firmware/efi/libstub/x86-stub.stub.o] Error 1
+
+Signed-off-by: Elena Reshetova <elena.reshetova@intel.com>
+---
+ drivers/firmware/efi/libstub/x86-stub.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/firmware/efi/libstub/x86-stub.c b/drivers/firmware/efi/libstub/x86-stub.c
+index 26f47210c..68855d109 100644
+--- a/drivers/firmware/efi/libstub/x86-stub.c
++++ b/drivers/firmware/efi/libstub/x86-stub.c
+@@ -36,7 +36,12 @@ static void detect_intel_tdx(void)
+ {
+ 	u32 eax, sig[3];
+ 
+-	cpuid_count(TDX_CPUID_LEAF_ID, 0, &eax, &sig[0], &sig[2], &sig[1]);
++	asm volatile(".ifnc %%ebx,%3 ; movl  %%ebx,%3 ; .endif	\n\t"
++		     "cpuid					\n\t"
++		     ".ifnc %%ebx,%3 ; xchgl %%ebx,%3 ; .endif	\n\t"
++		    : "=a" (eax), "=c" (sig[2]), "=d" (sig[1]), "=b" (sig[0])
++		    : "a" (TDX_CPUID_LEAF_ID), "c" (0)
++	);
+ 
+ 	if (memcmp("IntelTDX    ", sig, 12))
+ 		return;
+-- 
+2.34.1
+

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/0001-x86-MM-Use-pgprot_cc_guest-in-__ioremap_caller-for-T.patch
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/0001-x86-MM-Use-pgprot_cc_guest-in-__ioremap_caller-for-T.patch
@@ -1,0 +1,60 @@
+From e134218ff53a48a67a716fc14a47f34aa8644977 Mon Sep 17 00:00:00 2001
+From: Yuan Yao <yuan.yao@intel.com>
+Date: Mon, 13 Jun 2022 13:24:13 +0800
+Subject: [PATCH 1/1] x86: MM: Use pgprot_cc_guest() in __ioremap_caller() for
+ TDX guest only
+
+Guard pgprot_cc_guest() in __ioremap_caller() by
+cc_platform_has(CC_ATTR_GUEST_TDX).
+
+Otherwise the td_info.gpa_width it based on is not initialized
+correctly, which lead to at least UBSAN checking failure:
+
+UBSAN: shift-out-of-bounds in arch/x86/kernel/tdx.c:170:14
+shift exponent 4294967295 is too large for 64-bit type
+'long long unsigned int'
+CPU: 0 PID: 0 Comm: swapper/0 Not tainted 5.15.0-mvp3v8-5-generic
+ show_stack+0x52/0x58
+ dump_stack_lvl+0x4a/0x5f
+ dump_stack+0x10/0x12
+ ubsan_epilogue+0x9/0x45
+ __ubsan_handle_shift_out_of_bounds.cold+0x61/0xe9
+ tdx_shared_mask.cold+0x1b/0x28
+ __ioremap_caller+0x317/0x380
+ ioremap_cache+0x1a/0x20
+ acpi_os_map_iomem+0x1d1/0x200
+ acpi_os_map_memory+0xe/0x10
+ acpi_tb_acquire_table+0x42/0x6d
+ acpi_tb_validate_table+0x4a/0x82
+ acpi_tb_validate_temp_table+0x25/0x27
+ acpi_tb_verify_temp_table+0x42/0x1ce
+ acpi_reallocate_root_table+0x144/0x172
+ acpi_early_init+0x4f/0xdf
+ start_kernel+0x411/0x4d3
+ x86_64_start_reservations+0x24/0x26
+ x86_64_start_kernel+0xe9/0xf0
+ secondary_startup_64_no_verify+0xd1/0xdb
+
+Fixes: 16981b887d28 ("x86/tdx: Add cmdline option to force use of ioremap_shared")
+Signed-off-by: Yuan Yao <yuan.yao@intel.com>
+---
+ arch/x86/mm/ioremap.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/x86/mm/ioremap.c b/arch/x86/mm/ioremap.c
+index b22acd03f7db..96aae17b4aad 100644
+--- a/arch/x86/mm/ioremap.c
++++ b/arch/x86/mm/ioremap.c
+@@ -261,7 +261,8 @@ __ioremap_caller(resource_size_t phys_addr, unsigned long size,
+ 	prot = PAGE_KERNEL_IO;
+ 	if ((io_desc.flags & IORES_MAP_ENCRYPTED) || encrypted)
+ 		prot = pgprot_encrypted(prot);
+-	else if (shared || ioremap_force_shared || !cc_platform_has(CC_ATTR_GUEST_DEVICE_FILTER))
++	else if (cc_platform_has(CC_ATTR_GUEST_TDX) &&
++		 (shared || ioremap_force_shared || !cc_platform_has(CC_ATTR_GUEST_DEVICE_FILTER)))
+ 		prot = pgprot_cc_guest(prot);
+ 
+ 	switch (pcm) {
+-- 
+2.27.0
+

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/series
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/patches/series
@@ -1,0 +1,3 @@
+0001-efi-x86-stub-fix-absolute-symbol-reference.patch
+0001-X86-VIRTEXT-Fix-false-alarm-of-vmptrst-failure-in-ra.patch
+0001-x86-MM-Use-pgprot_cc_guest-in-__ioremap_caller-for-T.patch


### PR DESCRIPTION
Add 2 patches:
1. fix build error in SPR-BKC-PC-v8.8
2. fix kernel panic when enable TDX

Signed-off-by: jialeie <jialei.feng@intel.com>