### PR TITLE
start-qemu.sh: allow using CTRL-C in QEMU

### DIFF
--- a/start-qemu.sh
+++ b/start-qemu.sh
@@ -310,11 +310,16 @@ process_args() {
 }
 
 launch_vm() {
+    # remap CTRL-C to CTRL ]
+    echo "Remapping CTRL-C to CTRL-]"
+    stty intr ^]
     echo "Launch VM:"
     # shellcheck disable=SC2086,SC2090
     echo ${QEMU_CMD}
     # shellcheck disable=SC2086
     eval ${QEMU_CMD}
+    # restore CTRL-C mapping
+    stty intr ^c
 }
 
 process_args "$@"


### PR DESCRIPTION
Remap CTRL-C functionality to CTRL-] while in QEMU.
This allows using CTRL-C within QEMU without exiting QEMU.
In case we need to terminate QEMU, we can use CTRL-] instead.
Upon QEMU termination the CTRL-C functionality is restored.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>