### PR TITLE
Update libvirt template and code to support multiple distro

### DIFF
--- a/utils/pycloudstack/pycloudstack/dut.py
+++ b/utils/pycloudstack/pycloudstack/dut.py
@@ -4,6 +4,7 @@ Manage the DUT(Device Under Test)
 import logging
 import socket
 from contextlib import closing
+import os
 import cpuinfo
 
 __author__ = 'cpio'
@@ -87,3 +88,18 @@ class DUT:
             assert value is not None
             return int(value.strip())
         return None
+
+    @staticmethod
+    def get_distro():
+        """
+        Get host distro information
+        """
+        if os.path.exists("/etc/os-release"):
+            with open("/etc/os-release", "r", encoding="utf8") as fobj:
+                distro = fobj.read().lower().split()[0]
+        else:
+            LOG.error("/etc/os-release doesn't exist. Fall back to /usr/lib/os-release")
+            with open("/usr/lib/os-release", "r", encoding="utf8") as fobj:
+                distro = fobj.read().lower().split()[0]
+        assert distro is not None
+        return distro

--- a/utils/pycloudstack/pycloudstack/templates/legacy-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/legacy-base.xml
@@ -6,7 +6,7 @@
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
     <boot dev='hd'/>
-    <loader>/usr/share/qemu-kvm/bios.bin</loader>
+    <loader>REPLACEME_LOADER</loader>
     <kernel>REPLACEME_KERNEL</kernel>
     <cmdline>root=/dev/vda3 selinux=0 rw console=hvc0</cmdline>
   </os>
@@ -33,7 +33,7 @@
     <iothread id='1'/>
   </iothreadids>
   <devices>
-    <emulator>/usr/libexec/qemu-kvm</emulator>
+    <emulator>REPLACEME_QEMU</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' io='native' cache='none' iothread='1'/>
       <source file='REPLACEME_IMAGE'/>

--- a/utils/pycloudstack/pycloudstack/templates/ovmf-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/ovmf-base.xml
@@ -34,7 +34,7 @@
     <iothread id='1'/>
   </iothreadids>
   <devices>
-    <emulator>/usr/libexec/qemu-kvm</emulator>
+    <emulator>REPLACEME_QEMU</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' io='native' cache='none' iothread='1'/>
       <source file='REPLACEME_IMAGE'/>

--- a/utils/pycloudstack/pycloudstack/templates/sgx-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/sgx-base.xml
@@ -13,7 +13,7 @@
   </cpu>
   <os>
     <type arch='x86_64' machine='q35'>hvm</type>
-    <loader>/usr/share/qemu-kvm/bios.bin</loader>
+    <loader>REPLACEME_LOADER</loader>
     <boot dev='hd'/>
   </os>
   <features>
@@ -35,7 +35,7 @@
     <suspend-to-disk enabled='no'/>
   </pm>
   <devices>
-    <emulator>/usr/libexec/qemu-kvm</emulator>
+    <emulator>REPLACEME_QEMU</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
       <source file='REPLACEME_IMAGE' />

--- a/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
@@ -35,7 +35,7 @@
     <iothread id='1'/>
   </iothreadids>
   <devices>
-    <emulator>/usr/libexec/qemu-kvm</emulator>
+    <emulator>REPLACEME_QEMU</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' io='native' cache='none' iothread='1'/>
       <source file='REPLACEME_IMAGE'/>

--- a/utils/pycloudstack/pycloudstack/virtxml.py
+++ b/utils/pycloudstack/pycloudstack/virtxml.py
@@ -58,6 +58,7 @@ class VirtXml:
         self._sockets = None
         self._cores = None
         self._threads = None
+        self._qemu_exec = None
 
     @property
     def name(self):
@@ -292,6 +293,21 @@ class VirtXml:
         _, log_dom = self._find_single_element(["devices", "console", "log"])
         log_dom.set("file", new_file)
         self._logfile = new_file
+        self.save()
+
+    @property
+    def qemu_exec(self):
+        """
+        <domain>/<devices>/<emulator> - emulator field in xml
+        """
+        return self._qemu_exec
+
+    @qemu_exec.setter
+    def qemu_exec(self, qemu_exec):
+        if self._qemu_exec == qemu_exec:
+            return
+        if self._set_single_element_value(["devices", "emulator"], qemu_exec):
+            self._qemu_exec = qemu_exec
         self.save()
 
     @property

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -24,7 +24,7 @@ from .dut import DUT
 from .virtxml import VirtXml
 from .vmparam import VM_TYPE_LEGACY, VM_TYPE_EFI, VM_TYPE_TD, VM_TYPE_SGX, \
     VM_STATE_SHUTDOWN, VM_STATE_RUNNING, VM_STATE_PAUSE, VM_STATE_SHUTDOWN_IN_PROGRESS, \
-    BOOT_TYPE_GRUB, BIOS_BINARY_LEGACY, BIOS_OVMF_CODE, BIOS_OVMF_VARS
+    BOOT_TYPE_GRUB, BIOS_BINARY_LEGACY, QEMU_EXEC, BIOS_OVMF_CODE, BIOS_OVMF_VARS
 
 __author__ = 'cpio'
 
@@ -152,6 +152,7 @@ class VMMLibvirt(VMMBase):
         xmlobj.sockets = self.vminst.vmspec.sockets
         xmlobj.cores = self.vminst.vmspec.cores
         xmlobj.threads = self.vminst.vmspec.threads
+        xmlobj.qemu_exec = QEMU_EXEC
 
         var_filename = "OVMF_VARS." + xmlobj.uuid + ".fd"
         var_fullpath = os.path.join(tempfile.gettempdir(), var_filename)

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -10,16 +10,26 @@ BOOT_TYPE_DIRECT = "direct"
 BOOT_TYPE_GRUB = "grub"
 
 #
-# Please make sure the rootfs at partition /dev/vda3 in guest image
+# Set distro related parameters according to host distro
+# The rootfs is at partition /dev/vda3 in guest image for RHEL and CentOS Stream
+# The rootfs is at partition /dev/vda1 in guest image for Ubuntu
 # Also, hvc0 is the default console for TD VM, ttyS0 will be filtered
 # due to security concern.
 #
+with open("/etc/os-release", 'r', encoding="utf8") as f:
+    distro = f.read().lower().split()[0]
+if "ubuntu" not in distro:
+    BIOS_BINARY_LEGACY = "/usr/share/qemu-kvm/bios.bin"
+    QEMU_EXEC = "/usr/libexec/qemu-kvm"
+else:
+    BIOS_BINARY_LEGACY = "/usr/share/seabios/bios.bin"
+    QEMU_EXEC = "/usr/bin/qemu-system-x86_64"
+
 DEFAULT_CMDLINE = "root=/dev/vda3 rw selinux=0 console=hvc0 earlyprintk console=tty0"
 
 # Installed from the package of intel-mvp-qemu-kvm
 BIOS_OVMF_CODE = "/usr/share/qemu/OVMF_CODE.fd"
 BIOS_OVMF_VARS = "/usr/share/qemu/OVMF_VARS.fd"
-BIOS_BINARY_LEGACY = "/usr/share/qemu-kvm/bios.bin"
 
 VM_STATE_RUNNING = "running"
 VM_STATE_PAUSE = "paused"

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -10,22 +10,16 @@ BOOT_TYPE_DIRECT = "direct"
 BOOT_TYPE_GRUB = "grub"
 
 #
-# Set distro related parameters according to host distro
-# The rootfs is at partition /dev/vda3 in guest image for RHEL and CentOS Stream
-# The rootfs is at partition /dev/vda1 in guest image for Ubuntu
-# Also, hvc0 is the default console for TD VM, ttyS0 will be filtered
+# hvc0 is the default console for TD VM, ttyS0 will be filtered
 # due to security concern.
-#
-with open("/etc/os-release", 'r', encoding="utf8") as f:
-    distro = f.read().lower().split()[0]
-if "ubuntu" not in distro:
-    BIOS_BINARY_LEGACY = "/usr/share/qemu-kvm/bios.bin"
-    QEMU_EXEC = "/usr/libexec/qemu-kvm"
-else:
-    BIOS_BINARY_LEGACY = "/usr/share/seabios/bios.bin"
-    QEMU_EXEC = "/usr/bin/qemu-system-x86_64"
 
-DEFAULT_CMDLINE = "root=/dev/vda3 rw selinux=0 console=hvc0 earlyprintk console=tty0"
+DEFAULT_CMDLINE = "rw selinux=0 console=hvc0 earlyprintk console=tty0"
+
+QEMU_EXEC_CENTOS = "/usr/libexec/qemu-kvm"
+QEMU_EXEC_UBUNTU = "/usr/bin/qemu-system-x86_64"
+
+BIOS_BINARY_LEGACY_CENTOS = "/usr/share/qemu-kvm/bios.bin"
+BIOS_BINARY_LEGACY_UBUNTU = "/usr/share/seabios/bios.bin"
 
 # Installed from the package of intel-mvp-qemu-kvm
 BIOS_OVMF_CODE = "/usr/share/qemu/OVMF_CODE.fd"


### PR DESCRIPTION
1. Update qemu in xml template so that it reflects to corresponding distro qemu
2. Update vmguest.py to judge guest image distro and set corresponding rootfs to kernel command line based on distro.
3. Update virtxml.py to support qemu from different distro
4. Update vmm.py to judge host distro and set corresponding qemu and seabios information based on distro.
Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>