### PR TITLE
ubuntu 22.04: build host repo in build-repo.sh

### DIFF
--- a/build/ubuntu-22.04/build-repo.sh
+++ b/build/ubuntu-22.04/build-repo.sh
@@ -3,10 +3,12 @@
 set -ex
 
 THIS_DIR=$(dirname "$(readlink -f "$0")")
-GUEST_REPO="repo"
+GUEST_REPO="guest_repo"
+HOST_REPO="host_repo"
 
 pushd $THIS_DIR
 mkdir -p $GUEST_REPO
+mkdir -p $HOST_REPO
 
 build_shim () {
     cd intel-mvp-tdx-guest-shim
@@ -26,11 +28,39 @@ build_kernel () {
     cd intel-mvp-spr-kernel
     ./build.sh
     cp linux-image-unsigned-5.15.0-*.deb linux-headers-5.15.0-* linux-modules-5.15.0-* ../$GUEST_REPO/
+    cp linux-image-unsigned-5.15.0-*.deb linux-headers-5.15.0-* linux-modules-5.15.0-* linux-modules-extra-5.15.0-* ../$HOST_REPO/
+    cd ..
+}
+
+build_qemu () {
+    cd intel-mvp-spr-qemu
+    ./build.sh
+    cp qemu-system-x86_6.2*.deb qemu-system-common_6.2*.deb qemu-system-data_6.2*.deb ../$HOST_REPO/
+    cd ..
+}
+
+build_tdvf () {
+    cd intel-mvp-tdx-tdvf
+    ./build.sh
+    cp tdx-tdvf_*_all.deb ../$HOST_REPO/
+    cd ..
+}
+
+build_libvirt () {
+    cd intel-mvp-tdx-libvirt
+    ./build.sh
+
+    cp libvirt-clients_*.deb libvirt0_*.deb libvirt-daemon_*.deb libvirt-daemon-system_*.deb libvirt-daemon-system-systemd_*.deb \
+	    libvirt-daemon-driver-qemu_*.deb libvirt-daemon-config-network_*.deb libvirt-daemon-config-nwfilter_*.deb \
+	    libvirt-login-shell_*.deb libvirt-daemon-driver-lxc_*.deb ../$HOST_REPO/
     cd ..
 }
 
 build_shim
 build_grub
 build_kernel
+build_qemu
+build_tdvf
+build_libvirt
 
 popd

--- a/build/ubuntu-22.04/guest-image/tdx-guest-stack.sh
+++ b/build/ubuntu-22.04/guest-image/tdx-guest-stack.sh
@@ -9,7 +9,7 @@ THIS_DIR=$(dirname "$(readlink -f "$0")")
 IMG_URL=https://cloud-images.ubuntu.com/jammy/current
 CLOUD_IMG=jammy-server-cloudimg-amd64.img
 TD_IMG=td-guest-ubuntu-22.04.qcow2
-REPO_NAME="repo"
+REPO_NAME="guest_repo"
 REPO_LOCAL=${THIS_DIR}/../${REPO_NAME}
 
 if ! readlink -f ${REPO_LOCAL} ; then


### PR DESCRIPTION
Build TDX kernel, qemu, tdvf, libvirt debian packages in host_repo
host_repo is not an ubuntu repository list. You can install the debian packages directly.

Signed-off-by: jialeie <jialei.feng@intel.com>