### PR TITLE
ubuntu 22.04: install unmet build dependencies for qemu build

### DIFF
--- a/.github/workflows/pr-ubuntu-22.04-qemu.yml
+++ b/.github/workflows/pr-ubuntu-22.04-qemu.yml
@@ -24,6 +24,5 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt install --no-install-recommends --yes build-essential \
             fakeroot devscripts wget git equivs liblz4-tool sudo python-is-python3 pkg-config unzip
-          sudo apt -y install libcurl3-gnutls libudev1
           cd build/ubuntu-22.04/intel-mvp-spr-qemu/
           ./build.sh

--- a/build/ubuntu-22.04/intel-mvp-spr-qemu/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-spr-qemu/build.sh
@@ -33,6 +33,7 @@ prepare() {
     cp ${CURR_DIR}/debian/ ${CURR_DIR}/${PACKAGE}-${UPSTREAM_VERSION} -fr
 
     sudo apt update
+    sudo apt install systemd -y
     sudo DEBIAN_FRONTEND=noninteractive TZ=Asia/Shanghai apt install tzdata -y
 }
 


### PR DESCRIPTION
mk-build-deps failed to install some dependencies on ubuntu 22.04 VM.

Signed-off-by: jialeie <jialei.feng@intel.com>