### PR TITLE
ubuntu 22.04: optimize build process for automation

### DIFF
--- a/build/ubuntu-22.04/build-repo.sh
+++ b/build/ubuntu-22.04/build-repo.sh
@@ -4,6 +4,8 @@ THIS_DIR=$(dirname "$(readlink -f "$0")")
 GUEST_REPO="guest_repo"
 HOST_REPO="host_repo"
 
+export DEBIAN_FRONTEND=noninteractive
+
 build_check() {
     if [[ $(id -u) -eq 0 ]]; then
         echo "Running the whole script as root is not recommended. virnetsockettest might be failed when building libvirt as root"
@@ -26,7 +28,7 @@ build_grub () {
     cd ..
 
     # uninstall to avoid confilcts with libnvpair-dev
-    sudo apt remove grub2-build-deps-depends grub2-unsigned-build-deps-depends -y
+    sudo apt remove grub2-build-deps-depends grub2-unsigned-build-deps-depends -y || true
 }
 
 build_kernel () {

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/build.sh
@@ -35,8 +35,6 @@ prepare() {
     cp ${CURR_DIR}/linux-5.15.0/* ${CURR_DIR}/${PACKAGE}-${UPSTREAM_VERSION} -fr
 
     sudo apt update
-    sudo apt install software-properties-common -y
-    sudo add-apt-repository "deb-src http://mirrors.aliyun.com/ubuntu/ jammy main multiverse universe restricted" -y -s
     sudo DEBIAN_FRONTEND=noninteractive TZ=Asia/Shanghai apt install tzdata -y
 }
 

--- a/build/ubuntu-22.04/intel-mvp-spr-kernel/debian/rules.d/2-binary-arch.mk
+++ b/build/ubuntu-22.04/intel-mvp-spr-kernel/debian/rules.d/2-binary-arch.mk
@@ -117,8 +117,8 @@ $(stampdir)/stamp-install-%: MODSECKEY=$(builddir)/build-$*/certs/signing_key.pe
 $(stampdir)/stamp-install-%: MODPUBKEY=$(builddir)/build-$*/certs/signing_key.x509
 $(stampdir)/stamp-install-%: build_dir=$(builddir)/build-$*
 $(stampdir)/stamp-install-%: dkms_dir=$(call dkms_dir_prefix,$(builddir)/build-$*)
-$(stampdir)/stamp-install-%: enable_zfs = $(call custom_override,do_zfs,$*)
-$(stampdir)/stamp-install-%: enable_v4l2loopback = $(call custom_override,do_v4l2loopback,$*)
+#$(stampdir)/stamp-install-%: enable_zfs = $(call custom_override,do_zfs,$*)
+#$(stampdir)/stamp-install-%: enable_v4l2loopback = $(call custom_override,do_v4l2loopback,$*)
 $(stampdir)/stamp-install-%: dbgpkgdir_dkms = $(if $(filter true,$(skipdbg)),"",$(dbgpkgdir)/usr/lib/debug/lib/modules/$(abi_release)-$*/kernel)
 $(stampdir)/stamp-install-%: $(stampdir)/stamp-build-% $(stampdir)/stamp-install-headers
 	@echo Debug: $@ kernel_file $(kernel_file) kernfile $(kernfile) install_file $(install_file) instfile $(instfile)


### PR DESCRIPTION
1. Set non-interactive installation for all build dependencies.
2. Disable DKMS build for zfs and v4l2loopback to simplify the script.  They are not loaded in kernel by default