### PR TITLE
pytdxmeasure: update to new confidential computing measurement protocol

### DIFF
--- a/utils/pytdxmeasure/pytdxmeasure/actor.py
+++ b/utils/pytdxmeasure/pytdxmeasure/actor.py
@@ -10,7 +10,7 @@ from hashlib import sha384
 from .rtmr import RTMR
 from .tdreport import TdReport
 from .tdeventlog import TDEventLogEntry, TDEventLogType, TDEventLogSpecIdHeader
-from .tdel import TDEL
+from .ccel import CCEL
 from .binaryblob import BinaryBlob
 
 __author__ = "cpio"
@@ -36,15 +36,15 @@ class VerifyActor:
         """
         Get TD report and RTMR replayed by event log to do verification.
         """
-        # 1. Read TDEL from ACPI table at /sys/firmware/acpi/tables/TDEL
-        tdelobj = TDEL.create_from_acpi_file()
-        if tdelobj is None:
+        # 1. Read CCEL from ACPI table at /sys/firmware/acpi/tables/CCEL
+        ccelobj = CCEL.create_from_acpi_file()
+        if ccelobj is None:
             return
 
         # 2. Get the start address and length for event log area
         td_event_log_actor = TDEventLogActor(
-            tdelobj.log_area_start_address,
-            tdelobj.log_area_minimum_length)
+            ccelobj.log_area_start_address,
+            ccelobj.log_area_minimum_length)
 
         # 3. Collect event log and replay the RTMR value according to event log
         td_event_log_actor.replay()
@@ -89,17 +89,15 @@ class TDEventLogActor:
         self._event_logs = []
         self._rtmrs = {}
 
-    def _read(self, tdel_file="/sys/firmware/acpi/tables/data/TDEL"):
-        if not os.path.exists(tdel_file):
-            LOG.error("Could not find the TDEL file %s", tdel_file)
-            return None
+    def _read(self, ccel_file="/sys/firmware/acpi/tables/data/CCEL"):
+        assert os.path.exists(ccel_file), f"Could not find the CCEL file {ccel_file}"
         try:
-            with open(tdel_file, "rb") as fobj:
+            with open(ccel_file, "rb") as fobj:
                 self._data = fobj.read()
                 assert len(self._data) > 0
                 return self._data
         except (PermissionError, OSError):
-            LOG.error("Need root permission to open file %s", tdel_file)
+            LOG.error("Need root permission to open file %s", ccel_file)
             return None
 
     @staticmethod

--- a/utils/pytdxmeasure/pytdxmeasure/ccel.py
+++ b/utils/pytdxmeasure/pytdxmeasure/ccel.py
@@ -1,4 +1,4 @@
-""" TDEL ACPI table for TDX Event Log.
+""" CCEL ACPI table for TDX Event Log.
 
 see https://software.intel.com/content/dam/develop/external/us/en/documents/intel-tdx-guest-hypervisor-communication-interface.pdf> # pylint: disable=line-too-long
 
@@ -14,9 +14,9 @@ __author__ = "cpio"
 LOG = logging.getLogger(__name__)
 
 
-class TDEL(BinaryBlob):
+class CCEL(BinaryBlob):
     """
-    Manage th TDEL ACPI table. It should run within TD guest.
+    Manage the CCEL ACPI table. It should run within TD guest.
     """
 
     @property
@@ -44,6 +44,22 @@ class TDEL(BinaryBlob):
         return oem_id
 
     @property
+    def cc_type(self):
+        """
+        Confidential Computing type in integer
+        """
+        cc_type, _ = self.get_uint8(36)
+        return cc_type
+
+    @property
+    def cc_subtype(self):
+        """
+        Confidential Computing specific sub-type in integer
+        """
+        cc_subtype, _ = self.get_uint8(37)
+        return cc_subtype
+
+    @property
     def log_area_minimum_length(self):
         """
         LAML value in integer
@@ -66,30 +82,32 @@ class TDEL(BinaryBlob):
         super().dump()
 
         if not self.is_valid():
-            LOG.error("TDEL is not valid")
+            LOG.error("CCEL is not valid")
             return
 
         LOG.info("Revision:     %d", self.revision)
         LOG.info("Length:       %d", self.length)
         LOG.info("Checksum:     %02X", self.checksum)
         LOG.info("OEM ID:       %s", self.oem_id)
+        LOG.info("CC Type:      %s", self.cc_type)
+        LOG.info("CC Sub-type:  %s", self.cc_subtype)
         LOG.info("Log Lenght:   0x%08X", self.log_area_minimum_length)
         LOG.info("Log Address:  0x%08X", self.log_area_start_address)
 
     def is_valid(self):
         """
-        Judge whether the TDEL data is valid.
+        Judge whether the CCEL data is valid.
         - Check the signature
         - Check the length
         """
         return self.length > 0 and \
-            self.data[0:4] == b'TDEL' and \
+            self.data[0:4] == b'CCEL' and \
             self.length == self.data[4]
 
     @staticmethod
-    def create_from_acpi_file(acpi_file="/sys/firmware/acpi/tables/TDEL"):
+    def create_from_acpi_file(acpi_file="/sys/firmware/acpi/tables/CCEL"):
         """
-        Read the TDEL table from the /sys/firmware/acpi/tables/TDEL
+        Read the CCEL table from the /sys/firmware/acpi/tables/CCEL
         """
         if not os.path.exists(acpi_file):
             LOG.error("Could not find the ACPI file %s", acpi_file)
@@ -98,9 +116,9 @@ class TDEL(BinaryBlob):
         try:
             with open(acpi_file, "rb") as fobj:
                 data = fobj.read()
-                assert len(data) > 0 and data[0:4] == b'TDEL', \
-                    "Invalid TDEL table"
-                return TDEL(data)
+                assert len(data) > 0 and data[0:4] == b'CCEL', \
+                    "Invalid CCEL table"
+                return CCEL(data)
         except (PermissionError, OSError):
             LOG.error("Need root permission to open file %s", acpi_file)
             return None

--- a/utils/pytdxmeasure/pytdxmeasure/cli.py
+++ b/utils/pytdxmeasure/pytdxmeasure/cli.py
@@ -8,7 +8,7 @@ import logging.config
 from .actor import VerifyActor, TDEventLogActor
 from .tdreport import TdReport
 
-from .tdel import TDEL
+from .ccel import CCEL
 
 __author__ = "cpio"
 
@@ -41,19 +41,19 @@ class TDXEventLogsCmd(TDXMeasurementCmdBase):
         Run cmd
         """
 
-        LOG.info("=> Read TDEL ACPI Table")
-        tdelobj = TDEL.create_from_acpi_file()
-        if tdelobj is None:
+        LOG.info("=> Read CCEL ACPI Table")
+        ccelobj = CCEL.create_from_acpi_file()
+        if ccelobj is None:
             return
-        tdelobj.dump()
+        ccelobj.dump()
 
-        actor = TDEventLogActor(tdelobj.log_area_start_address,
-            tdelobj.log_area_minimum_length)
+        actor = TDEventLogActor(ccelobj.log_area_start_address,
+            ccelobj.log_area_minimum_length)
 
         LOG.info("")
         LOG.info("=> Read Event Log Data - Address: 0x%X(0x%X)",
-                 tdelobj.log_area_start_address,
-                 tdelobj.log_area_minimum_length)
+                 ccelobj.log_area_start_address,
+                 ccelobj.log_area_minimum_length)
         actor.dump_td_event_logs()
 
         LOG.info("")


### PR DESCRIPTION
New ACPI device changed to /sys/firmware/acpi/tables/CCEL
Add 2 fields in event log, CC type and CC subtype.
Please refer to section 4.3.3 CC-Event Log in GHCI specification for TDX 1.5


Signed-off-by: jialeie <jialei.feng@intel.com>