### PR TITLE
vmguest.py - fix issue that rootfs being added multiple times

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -69,10 +69,12 @@ class VMGuest:
         self.mem_numa = mem_numa
 
         # Update rootfs in kernel command line depending on distro
+        rootfs_ubuntu = "root=/dev/vda1"
+        rootfs_centos = "root=/dev/vda3"
         if guest_distro == "ubuntu":
-            self.cmdline.add_field_from_string("root=/dev/vda1")
+            self.cmdline.add_field_from_string(rootfs_ubuntu)
         else:
-            self.cmdline.add_field_from_string("root=/dev/vda3")
+            self.cmdline.add_field_from_string(rootfs_centos)
 
         self.ssh_forward_port = DUT.find_free_port()
         LOG.info("VM SSH forward: %d", self.ssh_forward_port)

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -86,7 +86,8 @@ class KernelCmdline:
         """
         Add a field from full string include key=value
         """
-        self._cmdline += " " + field_str
+        if not self.is_field_exists(field_str):
+            self._cmdline += " " + field_str
 
     def add_field(self, key, value=None):
         """


### PR DESCRIPTION
I noticed rootfs is added to kernel cmdline each time a new VM is created, which makes the parameter repeat. When there is already rootfs in kernel cmdline, do not add it one more time.
Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>