### PR TITLE
tdx-guest-stack.sh: fix error message

### DIFF
--- a/build/ubuntu-22.04/guest-image/tdx-guest-stack.sh
+++ b/build/ubuntu-22.04/guest-image/tdx-guest-stack.sh
@@ -18,7 +18,7 @@ if ! readlink -f ${REPO_LOCAL} ; then
 fi
 
 if ! command -v "virt-customize" ; then
-    echo "virt-customize not found, please install libguestfs-tools-c"
+    echo "virt-customize not found, please install libguestfs-tools"
     exit 1
 fi
 


### PR DESCRIPTION
Ubuntu: "virt-customize" is provided by "libguestfs-tools" package.
There does not seem to be "libguestfs-tools-c" package.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>