### PR TITLE
ubuntu/build-repo.sh: fix dependency conflict

### DIFF
--- a/build/ubuntu-22.04/build-repo.sh
+++ b/build/ubuntu-22.04/build-repo.sh
@@ -23,6 +23,7 @@ build_shim () {
 
 build_grub () {
     cd intel-mvp-tdx-guest-grub2
+    sudo apt remove libzfslinux-dev -y || true
     ./build.sh
     cp grub-efi-amd64_*_amd64.deb grub-efi-amd64-bin_*_amd64.deb ../$GUEST_REPO/
     cd ..


### PR DESCRIPTION
There is a package conflict, grub cannot be built with libzfslinux-dev installed.
However, libzfslinux-dev is required for other package(s) so at some point
the package will be installed.

Fix the conflict by uninistalling libzfslinux-dev before building grub.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>