### PR TITLE
refine start-qemu.sh, tdx-guest-stack.sh and secure_boot.md

### DIFF
--- a/build/ubuntu-22.04/guest-image/tdx-guest-stack.sh
+++ b/build/ubuntu-22.04/guest-image/tdx-guest-stack.sh
@@ -12,7 +12,7 @@ TD_IMG=td-guest-ubuntu-22.04.qcow2
 REPO_NAME="guest_repo"
 REPO_LOCAL=${THIS_DIR}/../${REPO_NAME}
 
-if ! readlink -f ${REPO_LOCAL} ; then
+if [[ ! -d ${REPO_LOCAL} ]] ; then
     echo "${REPO_LOCAL} does not exist, please build it via build-repo.sh"
     exit 1
 fi
@@ -43,7 +43,6 @@ ARGS+=" --edit '/etc/ssh/sshd_config:s/PasswordAuthentication no/PasswordAuthent
 ARGS+=" --run-command 'growpart /dev/sda 1'"
 ARGS+=" --run-command 'resize2fs /dev/sda1'"
 ARGS+=" --run-command 'ssh-keygen -A'"
-ARGS+=" --install wireless-regdb"
 ARGS+=" --run-command 'dpkg -i /srv/${REPO_NAME}/linux-*.deb'"
 ARGS+=" --run-command 'systemctl mask pollinate.service'"
 

--- a/doc/secure_boot.md
+++ b/doc/secure_boot.md
@@ -57,7 +57,7 @@ Regarding the use of various digital certificates, you can refer to the followin
 In this step, we need to enroll the generated key into TDVF using [tdvfkeyenroll](https://github.com/intel/tdx-tools/tree/main/utils/tdvfkeyenroll).
 
 ```sh
-cd utils/tdvf-key-enroll
+cd utils/tdvfkeyenroll
 make
 make install
 ```
@@ -65,7 +65,7 @@ make install
 Then execute the following command. Please replace `guid` with content of `myGUID.txt` generated above.
 
 ```
-tdvf-key-enroll -fd <absolute-path-to-OVMF_VARS.fd> \
+tdvfkeyenroll -fd <absolute-path-to-OVMF_VARS.fd> \
 -pk <pk-key-guid> <absolute-path-to-PK.cer> \
 -kek <kek-guid> <absolute-path-to-KEK.cer> \
 -db <db-key-guid> <absolute-path-to-DB.cer>
@@ -141,12 +141,7 @@ In this step, we will use these files:
 
 Next we can start the TD virtual machine. We have two ways: QEMU and Libvirt.
 
-By QEMU, we can modify [start-qemu.sh](https://github.com/intel/tdx-tools/blob/main/start-qemu.sh):
-
-+ confidential-guest-support=tdx ==> confidential-guest-support=lsec0
-+ tdx-guest,id=tdx ==> tdx-guest,id=lsec0
-
-After that, boot vm via
+By QEMU, we can use [start-qemu.sh](https://github.com/intel/tdx-tools/blob/main/start-qemu.sh):
 
 ```sh
 ./start-qemu.sh -i /path/to/td-guest.qcow2 -b grub -a /path/to/OVMF_VARS.sb.fd
@@ -157,7 +152,7 @@ as follows before running the usual virsh commands.
 
 + Add secure='yes': `<loader type='generic' secure='yes'>/usr/share/qemu/OVMF_CODE.fd</loader>`
 + Use OVMF_VARS.sb.fd: `<nvram>/path/to/OVMF_VARS.sb.fd</nvram>`
-+ Use the signed image: `<source file='/path/to/QCOW2-image'/>`
++ Use the signed image: `<source file='/path/to/td-guest.qcow2'/>`
 
 ### Verification
 

--- a/start-qemu.sh
+++ b/start-qemu.sh
@@ -178,9 +178,9 @@ process_args() {
             *) echo "Unknown disk image's format"; exit 1 ;;
     esac
 
-    # Change kernel cmdline if ROOT_PARTITION is not the default /dev/vda3
+    # Guest rootfs changes
     if [[ ${ROOT_PARTITION} != "/dev/vda3" ]]; then
-        KERNEL_CMD_NON_TD="root=${ROOT_PARTITION} rw console=hvc0"
+        KERNEL_CMD_NON_TD=${KERNEL_CMD_NON_TD//"/dev/vda3"/${ROOT_PARTITION}}
         KERNEL_CMD_TD="${KERNEL_CMD_NON_TD}"
     fi
 


### PR DESCRIPTION
start-qemu.sh: fix KERNEL_CMD_NON_TD being overwritten when appending root partition
tdx-guest-stack.sh: remove installation of unused package for ubuntu guest
secure_boot.md: fix typo tdvf-key-enroll to tdvfkeyenroll

Signed-off-by: jialeie <jialei.feng@intel.com>