### PR TITLE
doc/run_tests.md: add required packages for tests running

### DIFF
--- a/doc/run_tests.md
+++ b/doc/run_tests.md
@@ -15,7 +15,7 @@ running. It uses `CentOS Stream 8` as example distro.
   If your host distro is RHEL 8.5 or CentOS Stream 8:
 
     ```
-    sudo dnf install python3-virtualenv python3-libvirt-6.0.0 libguestfs-devel libvirt-devel python3-devel
+    sudo dnf install python3-virtualenv python3-libvirt libguestfs-devel libvirt-devel python3-devel gcc gcc-c++
     ```
 
   If your host distro is Ubuntu 22.04:


### PR DESCRIPTION
In a brand new environment, gcc and gcc-c++ are also required to setup test environment

Signed-off-by: Hao,Ruomeng <ruomeng.hao@intel.com>