### PR TITLE
build: update tdvf to 2022-tdvf-ww39.4

### DIFF
--- a/build/centos-stream-8/intel-mvp-tdx-tdvf/build.sh
+++ b/build/centos-stream-8/intel-mvp-tdx-tdvf/build.sh
@@ -4,7 +4,7 @@ set -e
 
 CURR_DIR=$(dirname "$(readlink -f "$0")")
 DOWNSTREAM_GIT_URI="https://github.com/tianocore/edk2-staging.git"
-DOWNSTREAM_TAG="tdvf-2022-ww20.1"
+DOWNSTREAM_TAG="2022-tdvf-ww39.4"
 SPEC_FILE="${CURR_DIR}/tdvf.spec"
 RPMBUILD_DIR="${CURR_DIR}/rpmbuild"
 
@@ -14,8 +14,6 @@ get_origin() {
         git clone --single-branch --branch ${DOWNSTREAM_TAG} \
             ${DOWNSTREAM_GIT_URI}
         pushd edk2-staging
-	    git submodule set-url UnitTestFrameworkPkg/Library/CmockaLib/cmocka \
-            https://github.com/clibs/cmocka
         git submodule init
         git submodule sync
         git submodule update

--- a/build/centos-stream-8/intel-mvp-tdx-tdvf/tdvf.spec
+++ b/build/centos-stream-8/intel-mvp-tdx-tdvf/tdvf.spec
@@ -3,8 +3,8 @@
 # This spec file began as CentOS's ovmf spec file, then cut down and modified.
 
 Name:       intel-mvp-tdx-tdvf
-Version:    2022.5.16
-Release:    ww20.1.mvp37
+Version:    2022.ww39.4
+Release:    mvp39
 Summary:    UEFI firmware for 64-bit virtual machines supporting trusted domains
 Group:      Applications/Emulators
 License:    BSD and OpenSSL and MIT
@@ -57,7 +57,7 @@ export PYTHON_COMMAND=python3
 
 make -C BaseTools
 source ./edksetup.sh
-build -p OvmfPkg/OvmfPkgX64.dsc \
+build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
       -a X64 -b DEBUG \
       -t GCC5 \
       -D DEBUG_ON_SERIAL_PORT=TRUE \
@@ -65,7 +65,7 @@ build -p OvmfPkg/OvmfPkgX64.dsc \
       -D TDX_EMULATION_ENABLE=FALSE \
       -D TDX_ACCEPT_PAGE_SIZE=2M
 
-build -p OvmfPkg/OvmfPkgX64.dsc \
+build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
       -a X64 -b RELEASE \
       -t GCC5 \
       -D DEBUG_ON_SERIAL_PORT=FALSE \
@@ -75,12 +75,12 @@ build -p OvmfPkg/OvmfPkgX64.dsc \
 
 %install
 mkdir -p %{buildroot}/usr/share/qemu
-cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/OVMF.debug.fd
-cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/
-cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/OVMF_CODE.debug.fd
-cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/
-cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_VARS.fd %{buildroot}/usr/share/qemu/
-cp Build/OvmfX64/RELEASE_GCC*/X64/DumpTdxEventLog.efi %{buildroot}/usr/share/qemu/DumpTdxEventLog.efi
+cp Build/IntelTdx/DEBUG_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/OVMF.debug.fd
+cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/
+cp Build/IntelTdx/DEBUG_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/OVMF_CODE.debug.fd
+cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/
+cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF_VARS.fd %{buildroot}/usr/share/qemu/
+#cp Build/IntelTdx/RELEASE_GCC*/X64/DumpTdxEventLog.efi %{buildroot}/usr/share/qemu/DumpTdxEventLog.efi
 
 %files
 %license License.txt
@@ -89,5 +89,5 @@ cp Build/OvmfX64/RELEASE_GCC*/X64/DumpTdxEventLog.efi %{buildroot}/usr/share/qem
 /usr/share/qemu/OVMF_CODE.debug.fd
 /usr/share/qemu/OVMF_CODE.fd
 /usr/share/qemu/OVMF_VARS.fd
-/usr/share/qemu/DumpTdxEventLog.efi
+#/usr/share/qemu/DumpTdxEventLog.efi
 

--- a/build/rhel-8/intel-mvp-tdx-tdvf/build.sh
+++ b/build/rhel-8/intel-mvp-tdx-tdvf/build.sh
@@ -4,7 +4,7 @@ set -e
 
 CURR_DIR=$(dirname "$(readlink -f "$0")")
 DOWNSTREAM_GIT_URI="https://github.com/tianocore/edk2-staging.git"
-DOWNSTREAM_TAG="tdvf-2022-ww20.1"
+DOWNSTREAM_TAG="2022-tdvf-ww39.4"
 SPEC_FILE="${CURR_DIR}/tdvf.spec"
 RPMBUILD_DIR="${CURR_DIR}/rpmbuild"
 
@@ -14,8 +14,6 @@ get_origin() {
         git clone --single-branch --branch ${DOWNSTREAM_TAG} \
             ${DOWNSTREAM_GIT_URI}
         pushd edk2-staging
-	    git submodule set-url UnitTestFrameworkPkg/Library/CmockaLib/cmocka \
-            https://github.com/clibs/cmocka
         git submodule init
         git submodule sync
         git submodule update

--- a/build/rhel-8/intel-mvp-tdx-tdvf/tdvf.spec
+++ b/build/rhel-8/intel-mvp-tdx-tdvf/tdvf.spec
@@ -3,8 +3,8 @@
 # This spec file began as CentOS's ovmf spec file, then cut down and modified.
 
 Name:       intel-mvp-tdx-tdvf
-Version:    2022.5.16
-Release:    ww20.1.mvp37
+Version:    2022.ww39.4
+Release:    mvp39
 Summary:    UEFI firmware for 64-bit virtual machines supporting trusted domains
 Group:      Applications/Emulators
 License:    BSD and OpenSSL and MIT
@@ -57,7 +57,7 @@ export PYTHON_COMMAND=python3
 
 make -C BaseTools
 source ./edksetup.sh
-build -p OvmfPkg/OvmfPkgX64.dsc \
+build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
       -a X64 -b DEBUG \
       -t GCC5 \
       -D DEBUG_ON_SERIAL_PORT=TRUE \
@@ -65,7 +65,7 @@ build -p OvmfPkg/OvmfPkgX64.dsc \
       -D TDX_EMULATION_ENABLE=FALSE \
       -D TDX_ACCEPT_PAGE_SIZE=2M
 
-build -p OvmfPkg/OvmfPkgX64.dsc \
+build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
       -a X64 -b RELEASE \
       -t GCC5 \
       -D DEBUG_ON_SERIAL_PORT=FALSE \
@@ -75,12 +75,12 @@ build -p OvmfPkg/OvmfPkgX64.dsc \
 
 %install
 mkdir -p %{buildroot}/usr/share/qemu
-cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/OVMF.debug.fd
-cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/
-cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/OVMF_CODE.debug.fd
-cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/
-cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_VARS.fd %{buildroot}/usr/share/qemu/
-cp Build/OvmfX64/RELEASE_GCC*/X64/DumpTdxEventLog.efi %{buildroot}/usr/share/qemu/DumpTdxEventLog.efi
+cp Build/IntelTdx/DEBUG_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/OVMF.debug.fd
+cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF.fd %{buildroot}/usr/share/qemu/
+cp Build/IntelTdx/DEBUG_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/OVMF_CODE.debug.fd
+cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF_CODE.fd %{buildroot}/usr/share/qemu/
+cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF_VARS.fd %{buildroot}/usr/share/qemu/
+#cp Build/IntelTdx/RELEASE_GCC*/X64/DumpTdxEventLog.efi %{buildroot}/usr/share/qemu/DumpTdxEventLog.efi
 
 %files
 %license License.txt
@@ -89,5 +89,5 @@ cp Build/OvmfX64/RELEASE_GCC*/X64/DumpTdxEventLog.efi %{buildroot}/usr/share/qem
 /usr/share/qemu/OVMF_CODE.debug.fd
 /usr/share/qemu/OVMF_CODE.fd
 /usr/share/qemu/OVMF_VARS.fd
-/usr/share/qemu/DumpTdxEventLog.efi
+#/usr/share/qemu/DumpTdxEventLog.efi
 

--- a/build/ubuntu-22.04/intel-mvp-tdx-tdvf/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-tdx-tdvf/build.sh
@@ -4,10 +4,10 @@ set -e
 
 CURR_DIR=$(dirname "$(readlink -f "$0")")
 DOWNSTREAM_GIT_URI="https://github.com/tianocore/edk2-staging.git"
-DOWNSTREAM_TAG="tdvf-2022-ww20.1"
+DOWNSTREAM_TAG="2022-tdvf-ww39.4"
 
 PACKAGE="tdx-tdvf"
-PACKAGE_VERSION="2022.5.16"
+PACKAGE_VERSION="2022.ww39.4"
 
 get_origin() {
     echo "**** Download origin package ****"
@@ -15,7 +15,6 @@ get_origin() {
     if [[ ! -f ${CURR_DIR}/edk2.tar.gz ]]; then
         git clone --single-branch --branch ${DOWNSTREAM_TAG} ${DOWNSTREAM_GIT_URI}
         pushd edk2-staging
-        git submodule set-url UnitTestFrameworkPkg/Library/CmockaLib/cmocka https://github.com/clibs/cmocka
         git submodule init
         git submodule sync
         git submodule update

--- a/build/ubuntu-22.04/intel-mvp-tdx-tdvf/debian/changelog
+++ b/build/ubuntu-22.04/intel-mvp-tdx-tdvf/debian/changelog
@@ -1,7 +1,34 @@
+tdx-tdvf (2022.9.26-ww39.5.mvp42) jammy; urgency=medium
+
+  * TDX build.
+    https://github.com/tianocore/edk2-staging/releases/tag/2022-tdvf-ww39.4
+
+ -- Jialei Feng <jialei.feng@intel.com>  Mon, 26 Sep 2022 13:06:00 +0800
+
+tdx-tdvf (2022.8.17-upstream2.mvp41) jammy; urgency=medium
+
+  * TDX build.
+    Use OvmfPkg/IntelTdx/IntelTdxX64.dsc
+
+ -- Jialei Feng <jialei.feng@intel.com>  Tue, 30 Aug 2022 11:47:00 +0800
+
+tdx-tdvf (2022.8.17-upstream2.mvp40) jammy; urgency=medium
+
+  * TDX build.
+    Upstream code base 2
+
+ -- Jialei Feng <jialei.feng@intel.com>  Wed, 17 Aug 2022 11:44:00 +0800
+
+tdx-tdvf (2022.8.8-upstream1.mvp39) jammy; urgency=medium
+
+  * TDX build.
+    Upstream code base 1
+
+ -- Jialei Feng <jialei.feng@intel.com>  Mon, 8 Aug 2022 21:44:00 +0800
+
 tdx-tdvf (2022.5.16-ww20.1.mvp38) jammy; urgency=medium
 
   * TDX build.
-    Installed to /usr/share/tdvf/
 
  -- Jialei Feng <jialei.feng@intel.com>  Thu, 28 Jun 2022 15:40:00 +0800
 

--- a/build/ubuntu-22.04/intel-mvp-tdx-tdvf/debian/rules
+++ b/build/ubuntu-22.04/intel-mvp-tdx-tdvf/debian/rules
@@ -42,7 +42,7 @@ undefine CONF_PATH
 override_dh_auto_build:
 	make -C BaseTools
 	source ./edksetup.sh && \
-	build -p OvmfPkg/OvmfPkgX64.dsc \
+	build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
 	      -a X64 -b DEBUG \
 	      -t GCC5 \
 	      -D DEBUG_ON_SERIAL_PORT=TRUE \
@@ -50,7 +50,7 @@ override_dh_auto_build:
 	      -D TDX_EMULATION_ENABLE=FALSE \
 	      -D TDX_ACCEPT_PAGE_SIZE=2M 
 	source ./edksetup.sh && \
-	build -p OvmfPkg/OvmfPkgX64.dsc \
+	build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
 	      -a X64 -b RELEASE \
 	      -t GCC5 \
 	      -D DEBUG_ON_SERIAL_PORT=FALSE \
@@ -60,11 +60,11 @@ override_dh_auto_build:
 
 override_dh_install:
 	mkdir -p $(DEST_DIR)
-	cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF.fd $(DEST_DIR)/OVMF.debug.fd
-	cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF.fd $(DEST_DIR)/
-	cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF_CODE.fd $(DEST_DIR)/OVMF_CODE.debug.fd
-	cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_CODE.fd $(DEST_DIR)/
-	cp Build/OvmfX64/RELEASE_GCC*/FV/OVMF_VARS.fd $(DEST_DIR)/
-	cp Build/OvmfX64/RELEASE_GCC*/X64/DumpTdxEventLog.efi $(DEST_DIR)/DumpTdxEventLog.efi
+	cp Build/IntelTdx/DEBUG_GCC*/FV/OVMF.fd $(DEST_DIR)/OVMF.debug.fd
+	cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF.fd $(DEST_DIR)/
+	cp Build/IntelTdx/DEBUG_GCC*/FV/OVMF_CODE.fd $(DEST_DIR)/OVMF_CODE.debug.fd
+	cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF_CODE.fd $(DEST_DIR)/
+	cp Build/IntelTdx/RELEASE_GCC*/FV/OVMF_VARS.fd $(DEST_DIR)/
+#	cp Build/IntelTdx/RELEASE_GCC*/X64/DumpTdxEventLog.efi $(DEST_DIR)/DumpTdxEventLog.efi
 
 


### PR DESCRIPTION
Use default submodule url for cmocka.

Signed-off-by: Feng, Jialei <jialei.feng@intel.com>