### PR TITLE
build: fix wrong path in build-repo.sh for Ubuntu

### DIFF
--- a/build/ubuntu-22.04/build-repo.sh
+++ b/build/ubuntu-22.04/build-repo.sh
@@ -41,7 +41,7 @@ build_kernel () {
 }
 
 build_qemu () {
-    cd intel-mvp-tdx-qemu
+    cd intel-mvp-tdx-qemu-kvm
     ./build.sh
     cp qemu-system-x86_6.2*.deb qemu-system-common_6.2*.deb qemu-system-data_6.2*.deb ../$HOST_REPO/
     cd ..


### PR DESCRIPTION
Ubuntu qemu build path is changed to intel-mvp-tdx-qemu-kvm same as RHEL.

Signed-off-by: Feng, Jialei <jialei.feng@intel.com>