### PR TITLE
build: add tdvf build check for ubuntu 22.04

### DIFF
--- a/.github/workflows/pr-test-build-centos-stream-8-kernel.yml
+++ b/.github/workflows/pr-test-build-centos-stream-8-kernel.yml
@@ -3,7 +3,7 @@ name: PR Test Building TDX Kernel Package for CentOS Stream 8
 on:
   pull_request:
     paths:
-    - 'build/centos-stream-8/intel-mvp-tdx-kernel/*'
+    - 'build/centos-stream-8/intel-mvp-tdx-kernel/**'
 
 jobs:
   build-packages:

--- a/.github/workflows/pr-test-build-centos-stream-8.yml
+++ b/.github/workflows/pr-test-build-centos-stream-8.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - 'build/centos-stream-8/**'
+    - '!build/centos-stream-8/intel-mvp-tdx-kernel/**'
 
 jobs:
   build-packages:

--- a/.github/workflows/pr-ubuntu-22.04-qemu.yml
+++ b/.github/workflows/pr-ubuntu-22.04-qemu.yml
@@ -3,7 +3,7 @@ name: Validate PR for Ubuntu-22.04 tdx-qemu-kvm
 on:
   pull_request:
     paths:
-    - 'build/ubuntu-22.04/intel-mvp-tdx-qemu-kvm/*'
+    - 'build/ubuntu-22.04/intel-mvp-tdx-qemu-kvm/**'
 
 jobs:
   build_package:

--- a/.github/workflows/pr-ubuntu-22.04-shim.yml
+++ b/.github/workflows/pr-ubuntu-22.04-shim.yml
@@ -3,7 +3,7 @@ name: Validate PR for Ubuntu-22.04 guest shim
 on:
   pull_request:
     paths:
-    - 'build/ubuntu-22.04/intel-mvp-tdx-guest-shim/*'
+    - 'build/ubuntu-22.04/intel-mvp-tdx-guest-shim/**'
 
 jobs:
   build_package:

--- a/.github/workflows/pr-ubuntu-22.04-tdvf.yml
+++ b/.github/workflows/pr-ubuntu-22.04-tdvf.yml
@@ -1,13 +1,13 @@
-name: Validate PR for Ubuntu-22.04 grub2
+name: Validate PR for Ubuntu-22.04 tdvf
 
 on:
   pull_request:
     paths:
-    - 'build/ubuntu-22.04/intel-mvp-tdx-guest-grub2/**'
+    - 'build/ubuntu-22.04/intel-mvp-tdx-tdvf/**'
 
 jobs:
   build_package:
-    name: Build grub2 for Ubuntu 22.04
+    name: Build tdvf for Ubuntu 22.04
     runs-on: ubuntu-22.04
     steps:
       - id: cleanup_workspace
@@ -23,5 +23,5 @@ jobs:
           sudo apt update
           sudo apt install --no-install-recommends --yes build-essential \
             fakeroot devscripts wget git equivs liblz4-tool sudo python-is-python3 pkg-config unzip
-          cd build/ubuntu-22.04/intel-mvp-tdx-guest-grub2/
+          cd build/ubuntu-22.04/intel-mvp-tdx-tdvf/
           ./build.sh

--- a/build/ubuntu-22.04/intel-mvp-tdx-tdvf/debian/patches/series
+++ b/build/ubuntu-22.04/intel-mvp-tdx-tdvf/debian/patches/series
@@ -1,4 +1,2 @@
 no-stack-protector-all-archs.diff
 brotlicompress-disable.diff
-0001-MdeModulePkg-NvmExpressDxe-fix-check-for-Cap.Css.patch
-0002-MdeModulePkg-NvmExpressPei-fix-check-for-NVM-command.patch


### PR DESCRIPTION
Add github workflow to check ubuntu tdvf PR.
Fix ubuntu tdvf build error.

Signed-off-by: Feng, Jialei <jialei.feng@intel.com>