### PR TITLE
doc: Update developer guide for release 2022WW42

### DIFF
--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -11,7 +11,9 @@ _NOTE:_ For production build in release purpose, please refer:
 
 ### Build and Setup Kernel
 
-TDX MVP stack uses [linux-kernel-dcp](https://github.com/intel/linux-kernel-dcp.git) for both host and guest kernel:
+The [TDX kernel patchset](https://github.com/intel/tdx-tools/blob/main/build/common/patches-tdx-kernel-MVP-5.15-v11.0.tar.gz) includes
+all patches based on kernel [v5.15](https://github.com/torvalds/linux/releases/tag/v5.15).
+
 
 1. Ensure you have installed the necessary packages to build Linux kernel. e.g. `libncurses5-dev libssl-dev build-essential openssl zlibc minizip lib libidn11-dev libbidn11 bison flex`
 Please install these packages via distro's package manager.
@@ -19,21 +21,25 @@ Please install these packages via distro's package manager.
 2. Download the kernel source code:
 
    ```
-   $ git clone https://github.com/intel/linux-kernel-dcp.git
+   $ wget https://github.com/intel/tdx-tools/blob/main/build/common/patches-tdx-kernel-MVP-5.15-v11.0.tar.gz
+   $ tar xf patches-tdx-kernel-MVP-5.15-v11.0.tar.gz
+   $ git clone --branch v5.15 https://github.com/torvalds/linux.git
+   $ cd linux
+   $ git am ../patches/*
    ```
 
 3. Kernel config
 
-   Please use the common platform's kernel config file [here](https://github.com/intel/linux-kernel-dcp/tree/main/arch/x86/configs)
-   for both TDX guest and host, or enable following specific kernel config on
-   any existing kernel config
-   ```
-   CONFIG_INTEL_TDX_GUEST=y
-   CONFIG_INTEL_TDX_ATTESTATION=y
-   CONFIG_INTEL_TDX_HOST=y
-   ```
+   - For RHEL
+      Please use the common platform's kernel config file [here](https://github.com/intel/tdx-tools/blob/main/build/rhel-8/intel-mvp-tdx-kernel/tdx-base.config)
+      for both TDX guest and host, then merge the detal config for [host](https://github.com/intel/tdx-tools/blob/main/build/rhel-8/intel-mvp-tdx-kernel/kernel-x86_64-rhel.config)
+      or [guest](https://github.com/intel/tdx-tools/blob/main/build/rhel-8/intel-mvp-tdx-kernel/kernel-x86_64-guest-rhel.config)
+
+   - For Ubuntu
+      Please use the common config file [here](https://github.com/intel/tdx-tools/blob/main/build/ubuntu-22.04/intel-mvp-tdx-kernel/debian.master/config/amd64/config.common.amd64)
+      , then merge the TDX flavour [here](https://github.com/intel/tdx-tools/blob/main/build/ubuntu-22.04/intel-mvp-tdx-kernel/debian.master/config/amd64/config.flavour.generic)
+
    Please refer [TDX kernel documentation](https://github.com/intel/linux-kernel-dcp/blob/main/Documentation/virt/kvm/intel-tdx.rst)
-   and CONFIG_INTEL_TDX_GUEST, CONFIG_INTEL_TDX_HOST at [here](https://github.com/intel/linux-kernel-dcp/blob/main/arch/x86/Kconfig)
 
 4. Build kernel
 
@@ -52,7 +58,12 @@ Please install these packages via distro's package manager.
 2. Download QEMU source code:
 
    ```
-   $ git clone https://github.com/intel/qemu-dcp.git
+   $ rm patches || true
+   $ wget https://github.com/intel/tdx-tools/raw/main/build/common/patches-tdx-qemu-MVP-QEMU-6.2-v3.1.tar.gz
+   $ tar xf patches-tdx-qemu-MVP-QEMU-6.2-v3.1.tar.gz
+   $ git clone https://github.com/qemu/qemu.git
+   $ cd qemu
+   $ git checkout 4c127fdbe81d66e7cafed90908d0fd1f6f2a6cd0
    ```
 
 3. Build QEMU:
@@ -115,20 +126,20 @@ Please install these packages via distro's package manager.
    $ make -C BaseTools
    $ make -C BaseTools/Source/C
    $ source ./edksetup.sh
-   $ build -p OvmfPkg/OvmfPkgX64.dsc \
-      -a X64 -b DEBUG \
-      -t GCC5 \
-      -D DEBUG_ON_SERIAL_PORT=TRUE \
-      -D TDX_MEM_PARTIAL_ACCEPT=512 \
-      -D TDX_EMULATION_ENABLE=FALSE \
-      -D TDX_ACCEPT_PAGE_SIZE=2M
-   $ build -p OvmfPkg/OvmfPkgX64.dsc \
-      -a X64 -b RELEASE \
-      -t GCC5 \
-      -D DEBUG_ON_SERIAL_PORT=FALSE \
-      -D TDX_MEM_PARTIAL_ACCEPT=512 \
-      -D TDX_EMULATION_ENABLE=FALSE \
-      -D TDX_ACCEPT_PAGE_SIZE=2M
+   $ build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
+         -a X64 -b DEBUG \
+         -t GCC5 \
+         -D DEBUG_ON_SERIAL_PORT=TRUE \
+         -D TDX_MEM_PARTIAL_ACCEPT=512 \
+         -D TDX_EMULATION_ENABLE=FALSE \
+         -D TDX_ACCEPT_PAGE_SIZE=2M
+   $ build -p OvmfPkg/IntelTdx/IntelTdxX64.dsc \
+         -a X64 -b RELEASE \
+         -t GCC5 \
+         -D DEBUG_ON_SERIAL_PORT=FALSE \
+         -D TDX_MEM_PARTIAL_ACCEPT=512 \
+         -D TDX_EMULATION_ENABLE=FALSE \
+         -D TDX_ACCEPT_PAGE_SIZE=2M
 
    $ mkdir -p /opt/tdx/tdvf/
    $ cp Build/OvmfX64/DEBUG_GCC*/FV/OVMF.fd /opt/tdx/tdvf/OVMF.debug.fd


### PR DESCRIPTION
1. linux-kernel-dcp was removed, so update steps to use patchset approach to build kernel for developer
2. qemu-dcp was removed, so update steps to use patchset approach to build qemu-kvm for developer
3. Update TDVF build step for new rebase

Signed-off-by: Lu, Ken <ken.lu@intel.com>