### PR TITLE
start-qemu.sh: add support for VMs with SGX

### DIFF
--- a/start-qemu.sh
+++ b/start-qemu.sh
@@ -37,6 +37,7 @@ fi
 # VM configurations
 CPUS=1
 MEM=2G
+SGX_EPC_SIZE=64M
 
 # Installed from the package of intel-mvp-tdx-tdvf
 OVMF_CODE="/usr/share/qemu/OVMF_CODE.fd"
@@ -83,7 +84,7 @@ usage() {
 Usage: $(basename "$0") [OPTION]...
   -i <guest image file>     Default is td-guest.qcow2 under current directory
   -k <kernel file>          Default is vmlinuz under current directory
-  -t [legacy|efi|td]        VM Type, default is "td"
+  -t [legacy|efi|td|sgx]    VM Type, default is "td"
   -b [direct|grub]          Boot type, default is "direct" which requires kernel binary specified via "-k"
   -p <Monitor port>         Monitor via telnet
   -f <SSH Forward port>     Host port for forwarding guest SSH
@@ -232,8 +233,13 @@ process_args() {
             fi
             QEMU_CMD+=" -bios ${LEGACY_BIOS} "
             ;;
+        "sgx")
+            PARAM_MACHINE+=",sgx-epc.0.memdev=mem0,sgx-epc.0.node=0"
+            QEMU_CMD+=" -cpu host,+sgx-provisionkey,+sgxlc,+sgx1"
+            QEMU_CMD+=" -object memory-backend-epc,id=mem0,size=${SGX_EPC_SIZE},prealloc=on"
+            ;;
         *)
-            error "Invalid ${VM_TYPE}, must be [legacy|efi|td]"
+            error "Invalid ${VM_TYPE}, must be [legacy|efi|td|sgx]"
             ;;
     esac
 


### PR DESCRIPTION
Although SGX is not supported in TD VMs, SGX functionality can be enabled in non-TD VMs. However, non-TD VMs do not support SGX by default. In order to enable SGX in VMs, QEMU needs to launch VMs with some additional SGX specific arguments, see:
  https://www.qemu.org/docs/master/system/i386/sgx.html

This patch implements SGX support by defining a new type of VM: "sgx".

Examples:
./start-qemu.sh -i <image> -b grub -t sgx
./start-qemu.sh -i <image> -b grub -s -t sgx
./start-qemu.sh -i <image> -b grub -s -t sgx -c 8
./start-qemu.sh -i <image> -k <kernel> -t sgx

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>