### PR TITLE
pycloudstack/virtxml.py: memory.setter: handle float instance (#188)

### DIFF
--- a/utils/pycloudstack/pycloudstack/virtxml.py
+++ b/utils/pycloudstack/pycloudstack/virtxml.py
@@ -169,6 +169,9 @@ class VirtXml:
     def memory(self, new_memory):
         if isinstance(new_memory, int):
             new_memory = str(new_memory)
+        else:
+            if isinstance(new_memory, float):
+                new_memory = str(round(new_memory))
         if self._memory == new_memory:
             return
         if self._set_single_element_value(["memory", ], new_memory):


### PR DESCRIPTION
Running the regression suit of tests:
  sudo ./run.sh -s regression

typically results in several tests failing with an error such as:
  text = 16777216.0
  ...
  TypeError: argument of type 'float' is not iterable

This patch detects attempts setting memory field in XML using 'float'. The 'float' value is first converted to 'int' using 'round' to eliminate decimal values and then the 'int' value is converted to a string.

Signed-off-by: Juro Bystricky <juro.bystricky@intel.com>