### PR TITLE
build.sh: fix the shell check issue by adding double quote

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ declare -A statuses
 for package in "${!pids[@]}"; do
   pid=${pids[$package]}
   set +e
-    wait $pid
+    wait "$pid"
     code=$?
   set -e
   if [ "$code" = "0" ]; then


### PR DESCRIPTION
Signed-off-by: Lu, Ken <ken.lu@intel.com>