### PR TITLE
template:fix bug of cpu parameter setting

### DIFF
--- a/utils/pycloudstack/pycloudstack/templates/legacy-base-perf.xml
+++ b/utils/pycloudstack/pycloudstack/templates/legacy-base-perf.xml
@@ -73,8 +73,4 @@
     </channel>
   </devices>
   <allowReboot value='no'/>
-  <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
-  </qemu:commandline>
 </domain>

--- a/utils/pycloudstack/pycloudstack/templates/legacy-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/legacy-base.xml
@@ -57,8 +57,4 @@
     </channel>
   </devices>
   <allowReboot value='no'/>
-  <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
-  </qemu:commandline>
 </domain>

--- a/utils/pycloudstack/pycloudstack/templates/ovmf-base-perf.xml
+++ b/utils/pycloudstack/pycloudstack/templates/ovmf-base-perf.xml
@@ -73,8 +73,4 @@
     </channel>
   </devices>
   <allowReboot value='no'/>
-  <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
-  </qemu:commandline>
 </domain>

--- a/utils/pycloudstack/pycloudstack/templates/ovmf-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/ovmf-base.xml
@@ -57,8 +57,4 @@
     </channel>
   </devices>
   <allowReboot value='no'/>
-  <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
-  </qemu:commandline>
 </domain>

--- a/utils/pycloudstack/pycloudstack/templates/sgx-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/sgx-base.xml
@@ -50,8 +50,4 @@
       <model type='virtio'/>
     </interface>
   </devices>
-  <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
-  </qemu:commandline>
 </domain>

--- a/utils/pycloudstack/pycloudstack/templates/tdx-base-perf.xml
+++ b/utils/pycloudstack/pycloudstack/templates/tdx-base-perf.xml
@@ -76,8 +76,4 @@
   <launchSecurity type='tdx'>
     <policy>0x10000001</policy>
   </launchSecurity>
-  <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
-  </qemu:commandline>
 </domain>

--- a/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
@@ -60,8 +60,4 @@
   <launchSecurity type='tdx'>
     <policy>0x10000001</policy>
   </launchSecurity>
-  <qemu:commandline>
-    <qemu:arg value='-cpu'/>
-    <qemu:arg value='host'/>
-  </qemu:commandline>
 </domain>


### PR DESCRIPTION
QEMU cpu parameters have been set by [vmm.py::set_cpu_params_xml](https://github.com/LeiZhou-97/tdx-tools/blob/06257cc2881e3bc80f642cda0f60852bfded9174/utils/pycloudstack/pycloudstack/vmm.py#L188) this function.

If use old template xml, will set cpu parameters twice. So this commit removes it in template.
```
<ns0:commandline>
    <ns0:arg value="-cpu"/>
    <ns0:arg value="host"/>
    <ns0:arg value="-cpu"/>
    <ns0:arg value="host,-shstk,-kvm-steal-time,pmu=off"/>
  </ns0:commandline>
```