### PR TITLE
Tests: fix test issue

### DIFF
--- a/tests/tests/test_tdvm_tsc.py
+++ b/tests/tests/test_tdvm_tsc.py
@@ -109,7 +109,7 @@ def test_tdvm_cpuid_tscfreq(base_td_guest_inst, vm_ssh_key, output):
     with open(saved_file, 'r', encoding="utf8") as fsaved:
         cpuid_strs = fsaved.readlines()
         for line in cpuid_strs:
-            if line.find('eax=0x00000001'):
+            if line.find('eax=0x00000001') != -1:
                 LOG.info("EAX value of cpuid#0x15.0 is 0x00000001")
                 found_exe_1 = True
                 break

--- a/utils/ovmfkeyenroll/ovmfkeyenroll/var_enroll.py
+++ b/utils/ovmfkeyenroll/ovmfkeyenroll/var_enroll.py
@@ -16,7 +16,8 @@ EFI_GLOBAL_VARIABLE = '8BE4DF61-93CA-11d2-AA0D-00E098032B8C'
 EFI_IMAGE_SECURITY_DATABASE_GUID = "d719b2cb-3d3a-4596-a3bc-dad00e67656f"
 EFI_CERT_X509_GUID = "a5c059a1-94e4-4aa7-87b5-ab155c2bf072"
 
-# pylint: disable=broad-except
+# pylint: disable=broad-exception-raised
+# pylint: disable=broad-exception-caught
 # pylint: disable=consider-using-f-string
 
 def is_guid(string):


### PR DESCRIPTION
1. Use cpu flags to varify TDX initilization in TD guest other than checking keyword in messages.
2. Fix incorrect usage of finding a sub-string.

Signed-off-by: Hao, Ruomeng <ruomeng.hao@intel.com>