### PR TITLE
templates/tdx-base-perf.xml: add memoryBacking using memfd

### DIFF
--- a/utils/pycloudstack/pycloudstack/templates/tdx-base-perf.xml
+++ b/utils/pycloudstack/pycloudstack/templates/tdx-base-perf.xml
@@ -2,6 +2,9 @@
   <name>REPLACEME_NAME</name>
   <uuid>REPLACEME_UUID</uuid>
   <memory unit='KiB'>REPLACEME_MEMORY</memory>
+  <memoryBacking>
+    <source type='memfd-private'/>
+  </memoryBacking>
   <vcpu placement='static' cpuset='35-46'>1</vcpu>
   <cputune>
     <vcpupin vcpu='0' cpuset='39'/>


### PR DESCRIPTION
This is to adapt for kernel 6.2 usage change about memfd. Corresponding
change is already adopted in template for functional test (tdx-base.xml).
The change here is used for performance test.