### PR TITLE
vmguest.py: give longer timeout to wait_for_state

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -301,7 +301,7 @@ class VMGuest:
         assert self.vmm is not None
         return self.vmm.state()
 
-    def wait_for_state(self, state, timeout=20):
+    def wait_for_state(self, state, timeout=30):
         """
         Wait for VM state to be given value until timeout
         """


### PR DESCRIPTION
Increase the timeout for wait_for_state from 20s to 30s to
avoid some false alarm in functional tests which are caused
by insufficient timeout.