### PR TITLE
vmguest.py: revert previous global timeout change

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -301,7 +301,7 @@ class VMGuest:
         assert self.vmm is not None
         return self.vmm.state()
 
-    def wait_for_state(self, state, timeout=30):
+    def wait_for_state(self, state, timeout=20):
         """
         Wait for VM state to be given value until timeout
         """


### PR DESCRIPTION
As suggestion from reviewers, the timeout value could be set
case by case. So revert previous change that has global impact.