### PR TITLE
python requirements.txt: use latest dependencies

### DIFF
--- a/attestation/pytdxmeasure/requirements.txt
+++ b/attestation/pytdxmeasure/requirements.txt
@@ -1,2 +1,2 @@
-wheel>=0.37.0
-setuptools>=56.0.0
+wheel
+setuptools

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,7 +13,7 @@ pytest-benchmark==3.2.3
 pyyaml==5.4.1
 libvirt-python
 virtualenv==20.4.6
-kubernetes>=12.0.1
+kubernetes
 urllib3>=1.26.5 # Regular Expression Denial of Service (ReDoS) required
 cpuid
 py-libnuma


### PR DESCRIPTION
As a recommended best known practice, using the latest version
for some dependencies to avoid some known issues.