### PR TITLE
Initial td-migration document and test scripts

### DIFF
--- a/utils/td-migration/README.md
+++ b/utils/td-migration/README.md
@@ -1,0 +1,208 @@
+# TD Migration
+
+## 1. Overview
+This feature is to meet the CSP who may want to relocate/migrate an executing Trust Domain (TD) from a source Trust Domain Extension (TDX) platform to a destination TDX platform in the cloud environment. Currently, td-migration only works on **TDX 1.5 (kernel-v6.2/tag-2023WW15 and later)**, TDX 1.0 do not support this feature.
+
+In this doc, the TD being migrated is called the source TD, and the TD created as a result of the migration is called the destination TD.
+
+
+## 2. Single Host Test Steps
+
+**NOTE**: each command needs one terminal, so please prepare 5 terminal tabs firstly or use tmux.
+
+### 2.1 Create MigTD
+
+The MigTD is designed to evaluate potential migration sources and targets for adherence to the TD Migration Policy and exchange MSK(Migration session Key) from the source platform to the destination platform. Creating MigTD is an additional workflow compared with live migration.
+
+NOTE: the default installation path of `migtd.bin` is "/usr/share/td-migration/migtd.bin" (provided by intel-mvp-tdx-migration pkg)
+
+```bash
+# create the MigTD_src to bind with src user TD 
+sudo ./migTD_src.sh 
+
+# create the MigTD_dst to bind with dst user TD 
+sudo ./migTD_dst.sh 
+```
+
+If you want to other path migtd binary, please use `-m` parameter to set the path.
+```bash
+sudo ./migTD_src.sh -m path/to/migtd.bin
+```
+
+If MigTD starts successfully, the console will display the below message.
+
+```console
+MigTD Version - 0.2.0
+Loop to wait for request
+```
+
+### 2.2 Launch user TD
+
+For live migration, it is a process that transfers source TD to dest TD. Before starting live migration, these two TDs need be prepared.
+
+NOTE: The default ROOT_PARTITION is `/dev/vda1`, which is for ubuntu guest TD. For RHEL, please add parameter `-r /dev/vda3`
+
+- Direct Boot
+```bash
+# create the source user TD
+sudo ./sourceTD.sh -i path/to/image -k path/to/kernel
+
+# create the destination user TD
+sudo ./destTD.sh -i path/to/image -k path/to/kernel
+```
+- GRUB Boot
+```bash
+# create the source user TD
+sudo ./sourceTD.sh -i path/to/image -b grub
+
+# create the destination user TD
+sudo ./destTD.sh -i path/to/image -b grub
+```
+
+### 2.3 Pre-Migration
+
+Before starting pre-migration, need to wait a while for user TDs to be ready.
+
+1. Create a channel for MigTD_src and MigTD_dst
+```bash
+sudo ./connect.sh
+```
+Check if it creates successfully.
+```console
+$ ps axu| grep socat
+root      112608  0.0  0.0  27828  3072 pts/5    S    Mar22   0:00 socat TCP4-LISTEN:9009,reuseaddr VSOCK-LISTEN:1234,fork
+root      112609  0.0  0.0  27828  3072 pts/5    S    Mar22   0:00 socat TCP4-CONNECT:127.0.0.1:9009,reuseaddr VSOCK-LISTEN:1235,fork
+```
+
+2. Start Pre-Migration
+```bash
+sudo ./pre-mig.sh
+```
+Check if pre-migrate success.
+
+```console
+$ dmesg
+[110722.032798] kvm_intel: Pre-migration is done, userspace pid=368587
+[110722.074132] kvm_intel: Pre-migration is done, userspace pid=368515
+```
+
+### 2.4 Live Migration
+
+Starts to transfer TD's data from source to destination.
+
+```bash
+sudo ./mig-flow.sh
+```
+After migration is complete, you can see the following message and use destTD normally.
+
+```console
+$ dmesg
+[110983.886989] migration flow is done, userspace pid 397008
+```
+
+## 3.Cross Host Test Steps
+
+**NOTE:** For cross-host live migration, you have to set up NFS server or use other ways to share the image/kernel for source TD and dest TD before starting the migration. (It means srcTD and dstTD can access the shared image/kernel together)
+
+### 3.1 Create MigTD
+
+NOTE: the default installation path of `migtd.bin` is "/usr/share/td-migration/migtd.bin" (provided by intel-mvp-tdx-migration pkg)
+
+```bash
+# create the MigTD_src to bind with src user TD 
+sudo ./migTD_src.sh 
+
+# create the MigTD_dst to bind with dst user TD 
+sudo ./migTD_dst.sh 
+```
+
+If you want to other path migtd binary, please use `-m` parameter to set the path.
+```bash
+sudo ./migTD_src.sh -m path/to/migtd.bin
+```
+
+If MigTD starts successfully, the console will display the below message.
+
+```console
+MigTD Version - 0.2.0
+Loop to wait for request
+```
+
+### 3.2 Launch user TD
+
+NOTE: The default ROOT_PARTITION is `/dev/vda1`, which is for ubuntu guest TD. For RHEL, please add parameter `-r /dev/vda3`
+
+- Direct Boot
+```bash
+# create the source user TD on source platform
+sudo ./sourceTD.sh -i path/to/image -k path/to/kernel
+
+# create the destination user TD on destination platform
+sudo ./destTD.sh -i path/to/image -k path/to/kernel
+```
+- GRUB Boot
+```bash
+# create the source user TD on source platform
+sudo ./sourceTD.sh -i path/to/image -b grub
+
+# create the destination user TD on destination platform
+sudo ./destTD.sh -i path/to/image -b grub
+```
+
+### 3.3 Pre-Migration
+
+This step has a little difference with the single host live migration.
+
+1. Create a channel for MigTD_src and MigTD_dst
+- Run this CMD on source platform
+```bash
+modprobe vhost_vsock
+socat TCP4-LISTEN:9009,reuseaddr VSOCK-LISTEN:1234,fork &
+```
+- Run this CMD on destination platform
+```bash
+modprobe vhost_vsock
+socat TCP4-CONNECT:<source-platform-ip>:9009,reuseaddr VSOCK-LISTEN:1235,fork &
+```
+
+2. Start Pre-Migration
+
+For current MigTD implementation, the following two commands need to be executed within 8 second, otherwise MigTD will time out.
+```console
+$ dmesg
+[110682.833587] kvm_intel: migtd_report_status: pre-migration failed, state=5
+```
+- Run this CMD on source platform
+```bash
+# Asking migtd-dst to connect to the src socat
+echo "qom-set /objects/tdx0/ vsockport 1234" | nc -U /tmp/qmp-sock-src
+```
+- Run this CMD on destination platform
+```bash
+# Asking migtd-dst to connect to the dst socat
+echo "qom-set /objects/tdx0/ vsockport 1235" | nc -U /tmp/qmp-sock-dst
+```
+Check if pre-migrate is successful on both platforms.
+
+```console
+$ dmesg
+[110722.032798] kvm_intel: Pre-migration is done, userspace pid=368587
+```
+
+### 3.4 Live Migration
+
+```bash
+sudo ./mig-flow.sh -i <dest-platform-ip>
+```
+After migration is complete, you can see the following message and use destTD normally.
+
+```console
+$ dmesg
+[110983.886989] migration flow is done, userspace pid 397008
+```
+
+## 4. Related Specification
+
+1. [Intel® TDX Module Architecture Specification: TD
+Migration](https://cdrdv2.intel.com/v1/dl/getContent/733578)
+2. [Intel® TDX Migration TD Design Guide](https://cdrdv2.intel.com/v1/dl/getContent/733580)

--- a/utils/td-migration/connect.sh
+++ b/utils/td-migration/connect.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+modprobe vhost_vsock
+socat TCP4-LISTEN:9009,reuseaddr VSOCK-LISTEN:1234,fork &
+socat TCP4-CONNECT:127.0.0.1:9009,reuseaddr VSOCK-LISTEN:1235,fork &

--- a/utils/td-migration/destTD.sh
+++ b/utils/td-migration/destTD.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -e
+
+# Set distro related parameters according to distro
+DISTRO=$(grep -w 'NAME' /etc/os-release)
+if [[ "$DISTRO" =~ .*"Ubuntu".* ]]; then
+    QEMU_EXEC="/usr/bin/qemu-system-x86_64"
+else
+    QEMU_EXEC="/usr/libexec/qemu-kvm"
+fi
+KERNEL=""
+GUEST_IMG=""
+OVMF="/usr/share/qemu/OVMF.fd"
+LOG="lm-dst.log"
+BOOT_TYPE="direct"
+TARGET_PID=$(pgrep migtd-dst)
+ROOT_PARTITION="/dev/vda1"
+INCOMING_PORT=6666
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -i <guest image file>     Guest image file 
+  -k <kernel file>          Kernel file
+  -b [direct|grub]          Boot type, default is "direct" which requires kernel binary specified via "-k"
+  -r <root partition>       root partition for direct boot, default is /dev/vda1
+  -p                        incoming port
+  -h                        Show this help
+EOM
+}
+
+process_args() {
+    while getopts "i:k:b:r:p:h" option; do
+        case "${option}" in
+            i) GUEST_IMG=$OPTARG;;
+            k) KERNEL=$OPTARG;;
+            b) BOOT_TYPE=$OPTARG;;
+            r) ROOT_PARTITION=$OPTARG;;
+            p) INCOMING_PORT=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+
+    case ${BOOT_TYPE} in
+        "direct")
+            if [[ ! -f ${KERNEL} ]]; then
+                usage
+                error "Kernel image file ${KERNEL} not exist. Please specify via option \"-k\""
+            fi
+            ;;
+        "grub")
+            ;;
+        *)
+            echo "Invalid ${BOOT_TYPE}, must be [direct|grub]"
+            exit 1
+            ;;
+    esac
+
+    if [[ ! -f ${GUEST_IMG} ]]; then
+        usage
+        error "Guest image file ${GUEST_IMG} not exist. Please specify via option \"-i\""
+    fi
+
+    if [[ ! -f ${QEMU_EXEC} ]]; then
+        error "Please install QEMU which supports TDX."
+    fi
+
+    if [[ ! -f ${OVMF} ]]; then
+        error "Could not find OVMF, please install first"
+    fi
+}
+
+error() {
+    echo -e "\e[1;31mERROR: $*\e[0;0m"
+    exit 1
+}
+
+launch_TDVM() {
+    QEMU_CMD="${QEMU_EXEC} 
+        -accel kvm 
+        -cpu host,pmu=off,-kvm-steal-time,-shstk,tsc-freq=1000000000 
+        -smp 4,threads=1,sockets=1 
+        -m 16G
+        -object tdx-guest,id=tdx0,sept-ve-disable=on,debug=off,migtd-pid=${TARGET_PID} 
+        -object memory-backend-memfd-private,id=ram1,size=16G
+        -machine q35,memory-backend=ram1,confidential-guest-support=tdx0,kernel_irqchip=split 
+        -bios ${OVMF} 
+        -chardev stdio,id=mux,mux=on,logfile=${LOG}
+        -drive file=$(readlink -f "${GUEST_IMG}"),if=virtio,id=virtio-disk0,format=qcow2 
+        -name process=lm-dst,debug-threads=on 
+        -no-hpet -nodefaults 
+        -D /run/qemu-dst.log -nographic -vga none 
+        -monitor unix:/tmp/qmp-sock-dst,server,nowait 
+        -device virtio-serial,romfile= 
+        -device virtconsole,chardev=mux -serial chardev:mux -monitor chardev:mux
+	    -device virtio-net-pci,netdev=mynet0,mac=00:16:3E:68:00:10,romfile=
+	    -netdev bridge,id=mynet0,br=virbr0
+		-incoming tcp:0:${INCOMING_PORT}"
+    if [[ ${BOOT_TYPE} == "direct" ]]; then
+        QEMU_CMD+=" -kernel $(readlink -f "${KERNEL}")"
+        QEMU_CMD+=" -append \"root=${ROOT_PARTITION} rw console=hvc0\" "
+    fi
+
+    eval "${QEMU_CMD}"
+}
+
+process_args "$@"
+launch_TDVM

--- a/utils/td-migration/mig-flow.sh
+++ b/utils/td-migration/mig-flow.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+DEST_IP="localhost"
+INCOMING_PORT=6666
+
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -i                        Destination platform ip, default is "localhost"
+  -p                        incoming port
+  -h                        Show this help
+EOM
+}
+
+process_args() {
+    while getopts "i:p:h" option; do
+        case "${option}" in
+            i) DEST_IP=$OPTARG;;
+            p) INCOMING_PORT=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+}
+
+migrate() {
+    echo "migrate_set_parameter max-bandwidth 100G" | nc -U /tmp/qmp-sock-src
+    echo "migrate -d tcp:${DEST_IP}:${INCOMING_PORT}" | nc -U /tmp/qmp-sock-src
+}
+
+process_args "$@"
+migrate

--- a/utils/td-migration/migTD_dst.sh
+++ b/utils/td-migration/migTD_dst.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Set distro related parameters according to distro
+DISTRO=$(grep -w 'NAME' /etc/os-release)
+if [[ "$DISTRO" =~ .*"Ubuntu".* ]]; then
+    QEMU_EXEC="/usr/bin/qemu-system-x86_64"
+else
+    QEMU_EXEC="/usr/libexec/qemu-kvm"
+fi
+
+MIGTD="/usr/share/td-migration/migtd.bin"
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -m <migtd file>           MigTD file
+  -h                        Show this help
+EOM
+}
+
+process_args() {
+    while getopts "m:h" option; do
+        case "${option}" in
+            m) MIGTD=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+}
+
+launch_migTD() {
+	$QEMU_EXEC -accel kvm \
+		-M q35 \
+		-cpu host,host-phys-bits,-kvm-steal-time,pmu=off \
+		-smp 1,threads=1,sockets=1 \
+		-m 1G \
+		-object tdx-guest,id=tdx0,sept-ve-disable=off,debug=off \
+		-object memory-backend-memfd-private,id=ram1,size=1G \
+		-machine q35,memory-backend=ram1,confidential-guest-support=tdx0,kernel_irqchip=split \
+		-bios "${MIGTD}" \
+		-device vhost-vsock-pci,id=vhost-vsock-pci1,guest-cid=36,disable-legacy=on \
+		-name migtd-dst,process=migtd-dst,debug-threads=on \
+		-no-hpet \
+		-nographic -vga none -nic none \
+		-serial mon:stdio
+}
+
+process_args "$@"
+launch_migTD

--- a/utils/td-migration/migTD_src.sh
+++ b/utils/td-migration/migTD_src.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Set distro related parameters according to distro
+DISTRO=$(grep -w 'NAME' /etc/os-release)
+if [[ "$DISTRO" =~ .*"Ubuntu".* ]]; then
+    QEMU_EXEC="/usr/bin/qemu-system-x86_64"
+else
+    QEMU_EXEC="/usr/libexec/qemu-kvm"
+fi
+
+MIGTD="/usr/share/td-migration/migtd.bin"
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -m <migtd file>           MigTD file
+  -h                        Show this help
+EOM
+}
+
+process_args() {
+    while getopts "m:h" option; do
+        case "${option}" in
+            m) MIGTD=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+}
+
+launch_migTD() {
+	$QEMU_EXEC -accel kvm \
+		-M q35 \
+		-cpu host,host-phys-bits,-kvm-steal-time,pmu=off \
+		-smp 1,threads=1,sockets=1 \
+		-m 1G \
+		-object tdx-guest,id=tdx0,sept-ve-disable=off,debug=off \
+		-object memory-backend-memfd-private,id=ram1,size=1G \
+		-machine q35,memory-backend=ram1,confidential-guest-support=tdx0,kernel_irqchip=split \
+		-bios "${MIGTD}" \
+		-device vhost-vsock-pci,id=vhost-vsock-pci1,guest-cid=18,disable-legacy=on \
+		-name migtd-src,process=migtd-src,debug-threads=on \
+		-no-hpet \
+		-nographic -vga none -nic none \
+		-serial mon:stdio
+}
+
+process_args "$@"
+launch_migTD

--- a/utils/td-migration/pre-mig.sh
+++ b/utils/td-migration/pre-mig.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Asking migtd-dst to connect to the src socat
+echo "qom-set /objects/tdx0/ vsockport 1234" | nc -U /tmp/qmp-sock-src
+
+# Asking migtd-dst to connect to the dst socat
+echo "qom-set /objects/tdx0/ vsockport 1235" | nc -U /tmp/qmp-sock-dst

--- a/utils/td-migration/sourceTD.sh
+++ b/utils/td-migration/sourceTD.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -e
+
+# Set distro related parameters according to distro
+DISTRO=$(grep -w 'NAME' /etc/os-release)
+if [[ "$DISTRO" =~ .*"Ubuntu".* ]]; then
+    QEMU_EXEC="/usr/bin/qemu-system-x86_64"
+else
+    QEMU_EXEC="/usr/libexec/qemu-kvm"
+fi
+KERNEL=""
+GUEST_IMG=""
+OVMF="/usr/share/qemu/OVMF.fd"
+LOG="lm-src.log"
+BOOT_TYPE="direct"
+TARGET_PID=$(pgrep migtd-src)
+ROOT_PARTITION="/dev/vda1"
+
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -i <guest image file>     Guest image file 
+  -k <kernel file>          Kernel file
+  -b [direct|grub]          Boot type, default is "direct" which requires kernel binary specified via "-k"
+  -r <root partition>       root partition for direct boot, default is /dev/vda1
+  -h                        Show this help
+EOM
+}
+
+process_args() {
+    while getopts "i:k:b:r:h" option; do
+        case "${option}" in
+            i) GUEST_IMG=$OPTARG;;
+            k) KERNEL=$OPTARG;;
+            b) BOOT_TYPE=$OPTARG;;
+            r) ROOT_PARTITION=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+
+    case ${BOOT_TYPE} in
+        "direct")
+            if [[ ! -f ${KERNEL} ]]; then
+                usage
+                error "Kernel image file ${KERNEL} not exist. Please specify via option \"-k\""
+            fi
+            ;;
+        "grub")
+            ;;
+        *)
+            echo "Invalid ${BOOT_TYPE}, must be [direct|grub]"
+            exit 1
+            ;;
+    esac
+
+    if [[ ! -f ${GUEST_IMG} ]]; then
+        usage
+        error "Guest image file ${GUEST_IMG} not exist. Please specify via option \"-i\""
+    fi
+
+    if [[ ! -f ${QEMU_EXEC} ]]; then
+        error "Please install QEMU which supports TDX."
+    fi
+
+    if [[ ! -f ${OVMF} ]]; then
+        error "Could not find OVMF, please install first"
+    fi
+}
+
+error() {
+    echo -e "\e[1;31mERROR: $*\e[0;0m"
+    exit 1
+}
+
+launch_TDVM() {
+    QEMU_CMD="${QEMU_EXEC} 
+        -accel kvm 
+        -cpu host,pmu=off,-kvm-steal-time,-shstk,tsc-freq=1000000000 
+        -smp 4,threads=1,sockets=1 
+        -m 16G
+        -object tdx-guest,id=tdx0,sept-ve-disable=on,debug=off,migtd-pid=${TARGET_PID} 
+        -object memory-backend-memfd-private,id=ram1,size=16G
+        -machine q35,memory-backend=ram1,confidential-guest-support=tdx0,kernel_irqchip=split 
+        -bios ${OVMF} 
+        -chardev stdio,id=mux,mux=on,logfile=${LOG}
+        -drive file=$(readlink -f "${GUEST_IMG}"),if=virtio,id=virtio-disk0,format=qcow2 
+        -name process=lm-src,debug-threads=on 
+        -no-hpet -nodefaults 
+        -D /run/qemu-src.log -nographic -vga none 
+        -monitor unix:/tmp/qmp-sock-src,server,nowait 
+        -device virtio-serial,romfile= 
+        -device virtconsole,chardev=mux -serial chardev:mux -monitor chardev:mux
+	    -device virtio-net-pci,netdev=mynet0,mac=00:16:3E:68:00:10,romfile=
+	    -netdev bridge,id=mynet0,br=virbr0"
+
+    if [[ ${BOOT_TYPE} == "direct" ]]; then
+        QEMU_CMD+=" -kernel $(readlink -f "${KERNEL}")"
+        QEMU_CMD+=" -append \"root=${ROOT_PARTITION} rw console=hvc0\" "
+    fi
+
+    eval "${QEMU_CMD}"
+}
+
+process_args "$@"
+launch_TDVM


### PR DESCRIPTION
1. Add the td-migration doc for customers who could follow the single or cross host td-migration test steps to verify its basic function
2. Develop some td-migration required test scripts to simplify its usage.

Signed-off-by: Zhou, Lei <lei.zhou@intel.com>