### PR TITLE
Add more option for user to use rtmr extend

### DIFF
--- a/attestation/pytdxmeasure/README.md
+++ b/attestation/pytdxmeasure/README.md
@@ -56,6 +56,14 @@ The Log Area Start Address (LASA) is from ACPI CCEL table. Please see [GHCI spec
     ./tdx_verify_rtmr
     ```
 
+4. Extend the RTMR
+
+    ```
+    ./tdx_extend_rtmr -s 'test_extend_rtmr' -i 3
+    ```
+    User can extend RTMR register with different kinds of data, including raw data(with '-r', must be 48B length), string data(with '-s',
+    will be converted to SHA384 digest) and SHA384 digest string(with '-d'). User can also change the index of RTMR register by using '-i'.
+
 ### Installation
 
 Build and install TDX Measurement Tool:

--- a/attestation/pytdxmeasure/examples/extend_ima.py
+++ b/attestation/pytdxmeasure/examples/extend_ima.py
@@ -19,6 +19,10 @@ Traditionally IMA measurements are anchored in Trusted Platform Module (TPM),\
     since vTPM is not available in TD guest. This utility can be used to anchor\
     IMA measurements into RTMR registers. Note that RTMR could only accept SHA384\
     digests.
+
+User have to set 'ima_hash=sha384' in kernel command line while boot and is able to\
+    switch the index of RTMR register to either 2 or 3 by using the flag '-i'. The\
+    digests are extended into RTMR[3] by default.
 """
 
 import os

--- a/attestation/pytdxmeasure/examples/extend_ima.py
+++ b/attestation/pytdxmeasure/examples/extend_ima.py
@@ -24,7 +24,6 @@ Traditionally IMA measurements are anchored in Trusted Platform Module (TPM),\
 import os
 import logging
 import argparse
-import codecs
 from pytdxmeasure.rtmr import RTMR
 
 DEFAULT_PATH_FOR_MEASUREMENT = '/sys/kernel/security/ima/ascii_runtime_measurements'
@@ -72,7 +71,7 @@ def extend_measurements_to_rtmr(contents, rtmr_index):
             LOG.info("Skip measurements not using sha384")
             continue
         content = content.split(":")
-        res = RTMR.extend_rtmr(str(codecs.decode(content[1],"hex")), rtmr_index)
+        res = RTMR.extend_rtmr("", "", content[1], rtmr_index)
         if res != RTMR.EXTEND_SUCCESS:
             LOG.error("Failed to extend %s", content[1])
 

--- a/attestation/pytdxmeasure/pytdxmeasure/cli.py
+++ b/attestation/pytdxmeasure/pytdxmeasure/cli.py
@@ -96,13 +96,14 @@ class TDXRTMRExtendCmd():
         logging.basicConfig(level=logging.DEBUG, format='%(message)s')
 
     @staticmethod
-    def run(extend_raw_data, extend_rtmr_index):
+    def run(extend_raw_data, extend_str_data, extend_digest_data, extend_rtmr_index):
         """
         Run cmd
         """
 
         LOG.info("=> Extend RTMR")
-        res = RTMR.extend_rtmr(extend_raw_data, extend_rtmr_index)
+        res = RTMR.extend_rtmr(extend_raw_data, extend_str_data,
+                               extend_digest_data, extend_rtmr_index)
         if res == RTMR.EXTEND_SUCCESS:
             LOG.info("Changed RTMR value in TD Report")
             TdReport.get_td_report().dump()

--- a/attestation/pytdxmeasure/tdx_extend_rtmr
+++ b/attestation/pytdxmeasure/tdx_extend_rtmr
@@ -5,12 +5,14 @@ import argparse
 from pytdxmeasure.cli import TDXRTMRExtendCmd
 
 parser = argparse.ArgumentParser(description="The utility to write data into RTMR register")
-parser.add_argument('-e', type=str, help='Extend value to rtmr register', dest='rtmr_extend_data')
-parser.add_argument('-r', type=int, default=2, help='RTMR register to extend', dest='extended_rtmr_index')
+parser.add_argument('-s', type=str, help='Extend string value to rtmr register', dest='rtmr_extend_str')
+parser.add_argument('-d', type=str, help='Extend digest value to rtmr register. Must be sha384 digest', dest='rtmr_extend_digest')
+parser.add_argument('-r', type=str, help='Extend raw value to rtmr register. Must be 48B.', dest='rtmr_extend_raw')
+parser.add_argument('-i', type=int, default=2, help='RTMR register to extend', dest='extended_rtmr_index')
 
 args = parser.parse_args()
 print(args)
 
-if args.rtmr_extend_data is not None:
-    TDXRTMRExtendCmd().run(args.rtmr_extend_data, args.extended_rtmr_index)
+if args.rtmr_extend_raw is not None or args.rtmr_extend_str is not None or args.rtmr_extend_digest is not None:
+    TDXRTMRExtendCmd().run(args.rtmr_extend_raw, args.rtmr_extend_str, args.rtmr_extend_digest, args.extended_rtmr_index)
 


### PR DESCRIPTION
* Provide 3 types of data input for rtmr extend 
     * extend with any length string(will be converted to sha384 digest automatically) 
     * extend with sha384 digest
     * extend with raw data(must be 48B length)
* Add extra readme for rtmr extend