### PR TITLE
vmguest.py: add check interval parameter

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -22,6 +22,7 @@ LOG = logging.getLogger(__name__)
 
 LOOPBACK = "127.0.0.1"
 DEFAULT_SSH_PORT = 22
+DEFAULT_CHECK_INTERVAL = 1
 
 
 class VMGuest:
@@ -158,7 +159,7 @@ class VMGuest:
         runner.runwait()
         return runner
 
-    def wait_for_ssh_ready(self, timeout=BOOT_TIMEOUT):
+    def wait_for_ssh_ready(self, timeout=BOOT_TIMEOUT, check_interval=DEFAULT_CHECK_INTERVAL):
         """
         Wait for the port of forwarded SSH ready until timeout
         @return True is ready, False is timeout
@@ -197,7 +198,7 @@ class VMGuest:
             if retcode != 0:
                 LOG.error("Fail to connect SSH for guest %s, connect error: %d", self.name, retcode)
                 sock.close()
-                time.sleep(1)
+                time.sleep(check_interval)
                 tnow = time.time()
                 continue
 


### PR DESCRIPTION
Add new parameter to control the check interval for wait_for_ssh_ready.
The default value is 1 (second). Callers can customize this value as their need.
e.g. some benchmark needs more frequent check.