### PR TITLE
td-migration/connect.sh: wait 3s before connect

### DIFF
--- a/utils/td-migration/connect.sh
+++ b/utils/td-migration/connect.sh
@@ -51,6 +51,7 @@ connect() {
     modprobe vhost_vsock
     if [[ ${TYPE} == "local" ]]; then
         socat TCP4-LISTEN:9009,reuseaddr VSOCK-LISTEN:1235,fork &
+        sleep 3
         socat TCP4-CONNECT:127.0.0.1:9009,reuseaddr VSOCK-LISTEN:1234,fork &
     else
         ssh root@"${DEST_IP}" -o ConnectTimeout=30 "modprobe vhost_vsock; nohup socat TCP4-LISTEN:9009,reuseaddr VSOCK-LISTEN:1235,fork > foo.out 2> foo.err < /dev/null &"


### PR DESCRIPTION
Without this wait time, we could get error like this when connect:

socat[24288] E connect(5, AF=2 127.0.0.1:9009, 16): Connection refused