### PR TITLE
td-migration: add timeout for nc

### DIFF
--- a/utils/td-migration/mig-flow.sh
+++ b/utils/td-migration/mig-flow.sh
@@ -32,8 +32,8 @@ process_args() {
 }
 
 migrate() {
-    echo "migrate_set_parameter max-bandwidth 100G" | nc -U /tmp/qmp-sock-src
-    echo "migrate -d tcp:${DEST_IP}:${INCOMING_PORT}" | nc -U /tmp/qmp-sock-src
+    echo "migrate_set_parameter max-bandwidth 100G" | nc -U /tmp/qmp-sock-src -w3
+    echo "migrate -d tcp:${DEST_IP}:${INCOMING_PORT}" | nc -U /tmp/qmp-sock-src -w3
 }
 
 process_args "$@"

--- a/utils/td-migration/pre-mig.sh
+++ b/utils/td-migration/pre-mig.sh
@@ -50,13 +50,13 @@ error() {
 pre_mig(){
     # Asking migtd-dst to connect to the dst socat
     if [[ ${TYPE} == "local" ]]; then
-        echo "qom-set /objects/tdx0/ vsockport 1235" | nc -U /tmp/qmp-sock-dst
+        echo "qom-set /objects/tdx0/ vsockport 1235" | nc -U /tmp/qmp-sock-dst -w3
     else 
-       ssh root@"${DEST_IP}" -o ConnectTimeout=30 "echo qom-set /objects/tdx0/ vsockport 1235 | nc -U /tmp/qmp-sock-dst"
+       ssh root@"${DEST_IP}" -o ConnectTimeout=30 "echo qom-set /objects/tdx0/ vsockport 1235 | nc -U /tmp/qmp-sock-dst -w3"
     fi
 
     # Asking migtd-dst to connect to the src socat
-    echo "qom-set /objects/tdx0/ vsockport 1234" | nc -U /tmp/qmp-sock-src
+    echo "qom-set /objects/tdx0/ vsockport 1234" | nc -U /tmp/qmp-sock-src -w3
 }
 
 process_args "$@"


### PR DESCRIPTION
For some version of nc, the default is no timeout that will hang the execution of of script.
Adding 3 seconds timeout can resolve this.