### PR TITLE
pycloudstack: update framework to support vtpm

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -153,7 +153,8 @@ disable=raw-checker-failed,
         too-many-instance-attributes,
         too-many-arguments,
         too-many-locals,
-        too-few-public-methods
+        too-few-public-methods,
+        too-many-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/utils/pycloudstack/pycloudstack/virtxml.py
+++ b/utils/pycloudstack/pycloudstack/virtxml.py
@@ -739,6 +739,17 @@ class VirtXml:
         self._add_new_element_by_parent(new_disk_leaf, ["target"], {"dev": "vdb", "bus": "virtio"})
         self.save()
 
+    def set_vtpm_param(self, vtpm_path, vtpm_log):
+        """
+        Set vtpm TD binary path and vTPM TD log path
+        """
+        self._add_new_element(["launchSecurity", "vtpm", "loader"])
+        self._set_single_element_value(["launchSecurity", "vtpm", "loader"], f"{vtpm_path}")
+        self._add_new_element(["launchSecurity", "vtpm", "log"])
+        self._set_single_element_value(["launchSecurity", "vtpm", "log"], f"{vtpm_log}")
+
+        self.save()
+
     @staticmethod
     def get_templates_dir():
         """

--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -9,12 +9,13 @@ import socket
 import errno
 import datetime
 import getpass
+import libvirt
 from .cmdrunner import SSHCmdRunner, NativeCmdRunner
 from .dut import DUT
 from .vmimg import VMImage
 from .vmm import VMMLibvirt
 from .vmparam import VM_TYPE_TD, VM_TYPE_SGX, BOOT_TYPE_DIRECT,\
-BOOT_TYPE_GRUB, HUGEPAGES_2M, BOOT_TIMEOUT, KernelCmdline, VMSpec
+BOOT_TYPE_GRUB, HUGEPAGES_2M, BOOT_TIMEOUT, KernelCmdline, VMSpec, VTPM_PATH
 
 __author__ = 'cpio'
 
@@ -53,7 +54,8 @@ class VMGuest:
                  vmm_class=None, cpu_ids=None, mem_numa=True,
                  io_mode=None, cache=None, diskfile_path=None,
                  migtd_pid=None, mig_hash=None, incoming_port=None,
-                 tsx=None, tsc=None, mwait=None):
+                 tsx=None, tsc=None, mwait=None,
+                 has_vtpm=False, vtpm_path=None, vtpm_log=None):
 
         self.vmid = vmid
         self.name = name
@@ -80,6 +82,9 @@ class VMGuest:
         self.tsx = tsx
         self.tsc = tsc
         self.mwait = mwait
+        self.has_vtpm = has_vtpm
+        self.vtpm_path = vtpm_path
+        self.vtpm_log = vtpm_log
 
         # Update rootfs in kernel command line depending on distro
         rootfs_ubuntu = "root=/dev/vda1"
@@ -281,12 +286,12 @@ class VMGuest:
         else:
             self.vmm.shutdown(mode)
 
-    def destroy(self, delete_image=False, delete_log=False):
+    def destroy(self, delete_image=False, delete_log=False, is_undefined=True):
         """
         Destroy VM Guest
         """
         LOG.debug("+ Destroy guest %s", self.name)
-        self.vmm.destroy()
+        self.vmm.destroy(is_undefined=is_undefined)
         if delete_image:
             self.image.destroy()
         if delete_log:
@@ -319,6 +324,21 @@ class VMGuest:
             time.sleep(1)
             count += 1
         return False
+
+    def get_vtpm_td_dom(self):
+        """
+        Get dom of vTPM TD which is binding with user TD
+        """
+        dom = None
+        dom_uuid = None
+
+        try:
+            dom_uuid = self.vmm.get_vtpm_id()
+        except libvirt.libvirtError:
+            LOG.warning("Unable to find the domain %s", self.vminst.vmid)
+            return dom, dom_uuid
+        dom = self.vmm.get_domain_by_uuid(dom_uuid)
+        return dom, dom_uuid
 
     def get_ip(self, force_refresh=False):
         """
@@ -368,7 +388,8 @@ class VMGuestFactory:
                hugepage_size=None, boot=BOOT_TYPE_DIRECT, disk_img=None,
                vsock=False, vsock_cid=3, io_mode=None, cache=None,
                diskfile_path=None, cpu_ids=None, migtd_pid=None, mig_hash=None,
-               incoming_port=None, tsx=None, tsc=None, mwait=None):
+               incoming_port=None, tsx=None, tsc=None, mwait=None, has_vtpm=False, vtpm_path=None,
+               vtpm_log=None):
         """
         Creat a VM.
         """
@@ -388,6 +409,17 @@ class VMGuestFactory:
         user_name = getpass.getuser()
         current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
         vm_name = f"{vmtype}-{user_name}-{current_time}"
+
+        # vTPM BIOS path and vTPM TD log
+        if has_vtpm is True:
+            if vtpm_path is not None:
+                vtpm_path = vtpm_path
+            else:
+                vtpm_path = VTPM_PATH
+            if vtpm_log is not None:
+                vtpm_log = vtpm_log
+            else:
+                vtpm_log = f"/tmp/{vm_name}_vtpm_td.log"               
 
         # SGX VM use grub to boot
         if vmtype == VM_TYPE_SGX:
@@ -410,7 +442,8 @@ class VMGuestFactory:
                        io_mode=io_mode, cache=cache,
                        diskfile_path=diskfile_path, cpu_ids=cpu_ids,
                        migtd_pid=migtd_pid, mig_hash=mig_hash, incoming_port=incoming_port,
-                       tsx=tsx, tsc=tsc, mwait=mwait)
+                       tsx=tsx, tsc=tsc, mwait=mwait, has_vtpm=has_vtpm,
+                       vtpm_path=vtpm_path, vtpm_log=vtpm_log)
 
         self.vms[vm_name] = inst
 

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -25,7 +25,7 @@ from .vmparam import VM_TYPE_LEGACY, VM_TYPE_EFI, VM_TYPE_TD, VM_TYPE_SGX, \
     VM_STATE_SHUTDOWN_IN_PROGRESS, BOOT_TYPE_GRUB, BIOS_BINARY_LEGACY_CENTOS, \
     BIOS_BINARY_LEGACY_UBUNTU, QEMU_EXEC_CENTOS, QEMU_EXEC_UBUNTU, \
     BIOS_OVMF, VM_TYPE_TD_PERF, VM_TYPE_EFI_PERF, VM_TYPE_LEGACY_PERF, \
-    VTPM_PATH, BIOS_OVMF_VTPM
+    BIOS_OVMF_VTPM
 
 __author__ = 'cpio'
 
@@ -173,10 +173,10 @@ class VMMLibvirt(VMMBase):
         if self.vminst.diskfile_path:
             xmlobj.set_disk(self.vminst.diskfile_path)
 
-        self.set_cpu_params_xml(xmlobj)
+        self._set_cpu_params_xml(xmlobj)
 
         if self.vminst.has_vtpm:
-            self.set_vtpm_xml(xmlobj)
+            self._set_vtpm_xml(xmlobj)
 
         if self.vminst.mwait is not None:
             xmlobj.set_overcommit_params(f"cpu-pm={self.vminst.mwait}")
@@ -190,7 +190,7 @@ class VMMLibvirt(VMMBase):
 
         return xmlobj
 
-    def set_vtpm_xml(self, xmlobj):
+    def _set_vtpm_xml(self, xmlobj):
         """
         set vtpm TD binary path for TD instance
         """
@@ -198,7 +198,7 @@ class VMMLibvirt(VMMBase):
             xmlobj.set_vtpm_param(self.vminst.vtpm_path, self.vminst.vtpm_log)
             xmlobj.loader = BIOS_OVMF_VTPM
 
-    def set_cpu_params_xml(self, xmlobj):
+    def _set_cpu_params_xml(self, xmlobj):
         """
         set specific cpu parameters in domain xml based on different vm type
         """
@@ -402,14 +402,12 @@ class VMMLibvirt(VMMBase):
         state, _ = dom.state()
         return state == libvirt.VIR_DOMAIN_SHUTOFF
 
-    def state(self, vtpm_dom=None):
+    def state(self):
         """
         Get VM state
         """
-        if vtpm_dom is not None:
-            dom = vtpm_dom
-        else:
-            dom = self._get_domain()
+        dom = self._get_domain()
+
         state, _ = dom.state()
         if state == libvirt.VIR_DOMAIN_RUNNING:
             return VM_STATE_RUNNING

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -24,7 +24,8 @@ from .vmparam import VM_TYPE_LEGACY, VM_TYPE_EFI, VM_TYPE_TD, VM_TYPE_SGX, \
     VM_STATE_SHUTDOWN, VM_STATE_RUNNING, VM_STATE_PAUSE, \
     VM_STATE_SHUTDOWN_IN_PROGRESS, BOOT_TYPE_GRUB, BIOS_BINARY_LEGACY_CENTOS, \
     BIOS_BINARY_LEGACY_UBUNTU, QEMU_EXEC_CENTOS, QEMU_EXEC_UBUNTU, \
-    BIOS_OVMF, VM_TYPE_TD_PERF, VM_TYPE_EFI_PERF, VM_TYPE_LEGACY_PERF
+    BIOS_OVMF, VM_TYPE_TD_PERF, VM_TYPE_EFI_PERF, VM_TYPE_LEGACY_PERF, \
+    VTPM_PATH, BIOS_OVMF_VTPM
 
 __author__ = 'cpio'
 
@@ -174,6 +175,9 @@ class VMMLibvirt(VMMBase):
 
         self.set_cpu_params_xml(xmlobj)
 
+        if self.vminst.has_vtpm:
+            self.set_vtpm_xml(xmlobj)
+
         if self.vminst.mwait is not None:
             xmlobj.set_overcommit_params(f"cpu-pm={self.vminst.mwait}")
 
@@ -185,6 +189,14 @@ class VMMLibvirt(VMMBase):
             xmlobj.cmdline = str(self.vminst.cmdline)
 
         return xmlobj
+
+    def set_vtpm_xml(self, xmlobj):
+        """
+        set vtpm TD binary path for TD instance
+        """
+        if self.vminst.vmtype in [VM_TYPE_TD, VM_TYPE_TD_PERF]:
+            xmlobj.set_vtpm_param(self.vminst.vtpm_path, self.vminst.vtpm_log)
+            xmlobj.loader = BIOS_OVMF_VTPM
 
     def set_cpu_params_xml(self, xmlobj):
         """
@@ -254,6 +266,25 @@ class VMMLibvirt(VMMBase):
     def __del__(self):
         self._close_virt()
 
+    def get_domain_by_uuid(self, domain_uuid=None):
+        """
+        Get a domain from specific UUID string
+        """
+        assert self._virt_conn is not None
+        try:
+            return self._virt_conn.lookupByUUIDString(domain_uuid)
+        except libvirt.libvirtError:
+            LOG.warning("Fail to get the domain %s", domain_uuid)
+            return None
+
+    def get_vtpm_id(self):
+        """
+        Get vtpm ID
+        """
+        dom = self._get_domain()
+        vtpm_id = re.search('<vtpmid>(.*)</vtpmid>', dom.XMLDesc()).group(1)
+        return vtpm_id
+
     def create(self, stop_at_begining=True):
         """
         Create a VM.
@@ -266,7 +297,7 @@ class VMMLibvirt(VMMBase):
         domain = self._virt_conn.defineXML(self._xml.tostring())
         domain.create()
 
-    def destroy(self):
+    def destroy(self, is_undefined=True):
         """
         Destroy a VM.
         Table of Contents:https://libvirt.org/html/libvirt-libvirt-domain.html
@@ -284,10 +315,11 @@ class VMMLibvirt(VMMBase):
                 except libvirt.libvirtError:
                     LOG.warning("Fail to delete the domain %s", self._xml.name)
 
-                try:
-                    dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
-                except libvirt.libvirtError:
-                    LOG.warning("Unable to undefine the domain %s", self._xml.name)
+                if is_undefined:
+                    try:
+                        dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+                    except libvirt.libvirtError:
+                        LOG.warning("Unable to undefine the domain %s", self._xml.name)
 
         # Delete XML file
         if os.path.exists(self._xml.filepath):
@@ -370,11 +402,14 @@ class VMMLibvirt(VMMBase):
         state, _ = dom.state()
         return state == libvirt.VIR_DOMAIN_SHUTOFF
 
-    def state(self):
+    def state(self, vtpm_dom=None):
         """
         Get VM state
         """
-        dom = self._get_domain()
+        if vtpm_dom is not None:
+            dom = vtpm_dom
+        else:
+            dom = self._get_domain()
         state, _ = dom.state()
         if state == libvirt.VIR_DOMAIN_RUNNING:
             return VM_STATE_RUNNING

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -31,6 +31,12 @@ BIOS_BINARY_LEGACY_UBUNTU = "/usr/share/seabios/bios.bin"
 # Installed from the package of intel-mvp-qemu-kvm
 BIOS_OVMF = "/usr/share/qemu/OVMF.fd"
 
+# OVMF for vTPM
+BIOS_OVMF_VTPM = "/usr/share/tdx-vtpm/OVMF.fd"
+
+# vTPM TD binary file
+VTPM_PATH = "/usr/share/tdx-vtpm/final.bin"
+
 VM_STATE_RUNNING = "running"
 VM_STATE_PAUSE = "paused"
 VM_STATE_SHUTDOWN = "shutdown"


### PR DESCRIPTION
1. vmguest.py: parameters are added to indicate whether a vTPM TD needs to be created along with TD
2. vmparam.py: Add vTPM TDVF binary path and vTPM TD binary path
3. vmm.py: update destroy method so that a VM can be destroyed but not undefined
4. virtxml.py: Add method to set vtpm fields in libvirt xml template