### PR TITLE
build: set pipefail in build-repo.sh

### DIFF
--- a/build/rhel-8/build-repo.sh
+++ b/build/rhel-8/build-repo.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+set -o pipefail
 
 THIS_DIR=$(dirname "$(readlink -f "$0")")
 STATUS_DIR="${THIS_DIR}/build-status"

--- a/build/ubuntu-22.04/build-repo.sh
+++ b/build/ubuntu-22.04/build-repo.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -ex
+set -o pipefail
 
 THIS_DIR=$(dirname "$(readlink -f "$0")")
 GUEST_REPO="guest_repo"


### PR DESCRIPTION
The script redirects each build log, set pipefail to return the status of build.sh.