### PR TITLE
migtd: update to v0.2.3

### DIFF
--- a/build/rhel-8/intel-mvp-tdx-migration/build.sh
+++ b/build/rhel-8/intel-mvp-tdx-migration/build.sh
@@ -6,7 +6,7 @@ CURR_DIR=$(dirname "$(readlink -f "$0")")
 RPMBUILD_DIR=${CURR_DIR}/rpmbuild
 SPEC_FILE="${CURR_DIR}/tdx-migration.spec"
 GIT_URI="https://github.com/intel/MigTD.git"
-GIT_TAG="2023ww25.3"
+GIT_TAG="v0.2.3"
 PKG_DIR="${CURR_DIR}"/migtd
 
 get_source() {

--- a/build/rhel-8/intel-mvp-tdx-migration/tdx-migration.spec
+++ b/build/rhel-8/intel-mvp-tdx-migration/tdx-migration.spec
@@ -3,8 +3,8 @@
 # This spec file began as CentOS's ovmf spec file, then cut down and modified.
 
 Name:       intel-mvp-tdx-migration
-Version:    2023ww25.3
-Release:    mvp6
+Version:    v0.2.3
+Release:    mvp9
 Summary:    Migration for 64-bit virtual machines supporting trusted domains
 Group:      Applications/Emulators
 License:    BSD and OpenSSL and MIT
@@ -52,10 +52,13 @@ cargo install cargo-xbuild
 rustup component add rust-src
 ./sh_script/preparation.sh
 cargo image
+cargo hash --image target/release/migtd.bin > ./migtd.servtd_info_hash
 
 %install
 mkdir -p %{buildroot}/usr/share/td-migration
 cp target/release/migtd.bin %{buildroot}/usr/share/td-migration
+cp migtd.servtd_info_hash %{buildroot}/usr/share/td-migration
 
 %files
 /usr/share/td-migration/migtd.bin
+/usr/share/td-migration/migtd.servtd_info_hash

--- a/build/ubuntu-22.04/intel-mvp-tdx-migration/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-tdx-migration/build.sh
@@ -4,7 +4,7 @@ set -e
 
 CURR_DIR=$(dirname "$(readlink -f "$0")")
 GIT_URI="https://github.com/intel/MigTD.git"
-GIT_TAG="2023ww25.3"
+GIT_TAG="v0.2.3"
 PKG_DIR="${CURR_DIR}"/migtd
 
 get_source() {
@@ -47,6 +47,7 @@ build() {
     cd "${PKG_DIR}"
     ./sh_script/preparation.sh
     cargo image
+    cargo hash --image target/release/migtd.bin > ./migtd.servtd_info_hash
     dpkg-source --before-build .
     debuild -uc -us -b
 }

--- a/build/ubuntu-22.04/intel-mvp-tdx-migration/debian/changelog
+++ b/build/ubuntu-22.04/intel-mvp-tdx-migration/debian/changelog
@@ -1,3 +1,21 @@
+td-migration (0.2.3-mvp9) jammy; urgency=medium
+
+  * https://github.com/intel/MigTD/releases/tag/v0.2.3
+
+ -- Jialei Feng <jialei.feng@intel.com>  Wed, 5 Jul 2023 14:08:00 +0800
+
+td-migration (2023ww27.1-mvp8) jammy; urgency=medium
+
+  * td-migration: add migtd.servtd_info_hash
+
+ -- Jialei Feng <jialei.feng@intel.com>  Tue, 4 Jul 2023 15:16:00 +0800
+
+td-migration (2023ww27.1-mvp7) jammy; urgency=medium
+
+  * td-migration: https://github.com/intel/MigTD/tree/2023ww27.1
+
+ -- Jialei Feng <jialei.feng@intel.com>  Mon, 3 Jul 2023 14:47:00 +0800
+
 td-migration (2023ww25.3-mvp6) jammy; urgency=medium
 
   * td-migration: use public https://github.com/intel/MigTD/tree/2023ww25.3

--- a/build/ubuntu-22.04/intel-mvp-tdx-migration/debian/rules
+++ b/build/ubuntu-22.04/intel-mvp-tdx-migration/debian/rules
@@ -2,7 +2,7 @@
 
 include /usr/share/dpkg/default.mk
 
-version := 2023ww25.3-mvp6
+version := 0.2.3-mvp9
 PACKAGE := td-migration
 INSTALL_DIR=/usr/share/td-migration/
 DEST_DIR := debian/$(PACKAGE)$(INSTALL_DIR)
@@ -23,3 +23,4 @@ override_dh_clean:
 override_dh_install:
 	mkdir -p $(DEST_DIR)
 	install -m 0664 target/release/migtd.bin $(DEST_DIR)/
+	install -m 0664 ./migtd.servtd_info_hash $(DEST_DIR)/


### PR DESCRIPTION
Add /usr/share/td-migration/migtd.servtd_info_hash.