### PR TITLE
kernel: allow pahole installation to downgrade version

### DIFF
--- a/build/ubuntu-22.04/intel-mvp-tdx-kernel/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-tdx-kernel/build.sh
@@ -37,7 +37,7 @@ prepare() {
     cp "${CURR_DIR}"/linux-5.19.17/* "${SOURCE_DIR}" -fr
 
     sudo apt update
-    sudo apt install pahole=1.22-8 -y
+    sudo apt install pahole=1.22-8 -y --allow-downgrades
     sudo DEBIAN_FRONTEND=noninteractive TZ=Asia/Shanghai apt install tzdata -y
 }
 


### PR DESCRIPTION
Allow the automatic downgrade of pahole during the installation, to also fix the "Load BTF from vmlinux: Invalid argument" issue on systems with an already newer pahole version.