### PR TITLE
pycloudstack: Support UPM 2M hugepage usage

### DIFF
--- a/utils/pycloudstack/pycloudstack/virtxml.py
+++ b/utils/pycloudstack/pycloudstack/virtxml.py
@@ -658,12 +658,14 @@ class VirtXml:
         """
         bind available cpuids
         """
+        assert len(cpu_ids) > 1, "Incorrect cpu_ids for cpu binding"
+
         # set iothread
         self._add_new_element(["cputune", "iothreadpin"],
-                              {"iothread": "1", "cpuset": f"{cpu_ids.pop(0)}"}, True)
+                              {"iothread": "1", "cpuset": f"{cpu_ids[0]}"}, True)
         vcpu_id = 0
         # bind specific vcpus for vm
-        for cpu_id in cpu_ids:
+        for cpu_id in cpu_ids[1:]:
             self._add_new_element(["cputune", "vcpupin"],
                                   {"vcpu": f"{vcpu_id}", "cpuset": f"{cpu_id}"}, True)
             vcpu_id += 1
@@ -737,6 +739,15 @@ class VirtXml:
             f"{self._cache}", "iothread": "2"})
         self._add_new_element_by_parent(new_disk_leaf, ["source"], {"file": f"{diskfile_path}"})
         self._add_new_element_by_parent(new_disk_leaf, ["target"], {"dev": "vdb", "bus": "virtio"})
+        self.save()
+
+    def set_hugepage_path(self, hugepage_path):
+        """
+        Set hugepage path for UPM hugepage usage
+        """
+        self._add_new_element(["memoryBacking", "path"])
+        self._set_single_element_value(["memoryBacking", "path"], f"{hugepage_path}")
+
         self.save()
 
     def set_vtpm_param(self, vtpm_path, vtpm_log):

--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -14,10 +14,10 @@ from .cmdrunner import SSHCmdRunner, NativeCmdRunner
 from .dut import DUT
 from .vmimg import VMImage
 from .vmm import VMMLibvirt
-from .vmparam import VM_TYPE_TD, VM_TYPE_SGX, BOOT_TYPE_DIRECT,\
-BOOT_TYPE_GRUB, HUGEPAGES_2M, BOOT_TIMEOUT, KernelCmdline, VMSpec, \
-VTPM_PATH, VM_STATE_SHUTDOWN, VM_STATE_RUNNING, VM_STATE_PAUSE, \
-VM_STATE_SHUTDOWN_IN_PROGRESS
+from .vmparam import VM_TYPE_TD, VM_TYPE_TD_PERF, VM_TYPE_SGX, \
+BOOT_TYPE_DIRECT, BOOT_TYPE_GRUB, HUGEPAGES_2M, BOOT_TIMEOUT, \
+KernelCmdline, VMSpec, VTPM_PATH, VM_STATE_SHUTDOWN, VM_STATE_RUNNING, \
+VM_STATE_PAUSE, VM_STATE_SHUTDOWN_IN_PROGRESS
 
 __author__ = 'cpio'
 
@@ -57,7 +57,7 @@ class VMGuest:
                  io_mode=None, cache=None, diskfile_path=None,
                  migtd_pid=None, mig_hash=None, incoming_port=None,
                  tsx=None, tsc=None, mwait=None,
-                 has_vtpm=False, vtpm_path=None, vtpm_log=None):
+                 has_vtpm=False, vtpm_path=None, vtpm_log=None,hugepage_path=None):
 
         self.vmid = vmid
         self.name = name
@@ -87,6 +87,7 @@ class VMGuest:
         self.has_vtpm = has_vtpm
         self.vtpm_path = vtpm_path
         self.vtpm_log = vtpm_log
+        self.hugepage_path = hugepage_path
 
         # Update rootfs in kernel command line depending on distro
         rootfs_ubuntu = "root=/dev/vda1"
@@ -408,13 +409,17 @@ class VMGuestFactory:
                vsock=False, vsock_cid=3, io_mode=None, cache=None,
                diskfile_path=None, cpu_ids=None, migtd_pid=None, mig_hash=None,
                incoming_port=None, tsx=None, tsc=None, mwait=None,
-               has_vtpm=False, vtpm_path=None, vtpm_log=None):
+               has_vtpm=False, vtpm_path=None, vtpm_log=None,hugepage_path=None):
         """
-        Creat a VM.
+        Create a VM.
         """
 
         if hugepage_size is None:
             hugepage_size = HUGEPAGES_2M
+
+        # UPM 2M hugepage requires hugepage_path for TD
+        if hugepages is True and vmtype in [VM_TYPE_TD, VM_TYPE_TD_PERF]:
+            assert hugepage_path is not None, "Please set hugepage_path"
 
         # default io mode is native
         if io_mode is None:
@@ -458,7 +463,7 @@ class VMGuestFactory:
                        diskfile_path=diskfile_path, cpu_ids=cpu_ids,
                        migtd_pid=migtd_pid, mig_hash=mig_hash, incoming_port=incoming_port,
                        tsx=tsx, tsc=tsc, mwait=mwait, has_vtpm=has_vtpm,
-                       vtpm_path=vtpm_path, vtpm_log=vtpm_log)
+                       vtpm_path=vtpm_path, vtpm_log=vtpm_log,hugepage_path=hugepage_path)
 
         self.vms[vm_name] = inst
 

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -225,6 +225,10 @@ class VMMLibvirt(VMMBase):
         elif self.vminst.vmtype in [VM_TYPE_TD, VM_TYPE_TD_PERF]:
             xmlobj.loader = BIOS_OVMF
 
+            # If TD has hugepage_path, set it to xml
+            if self.vminst.hugepage_path is not None:
+                xmlobj.set_hugepage_path(self.vminst.hugepage_path)
+
             param_cpu = ""
             if DUT.get_cpu_base_freq() < 1000000:
                 param_cpu = "host,-shstk,-kvm-steal-time,pmu=off,tsc-freq=1000000000"


### PR DESCRIPTION
1. UPM 2M huegpage require to specify a hugepage_path. Modify pycloudstack framework to add the parameter.
2. Fix a issue in bind_cpuids - keep cpu_ids list to make sure the list is consistent in cycling test.