### PR TITLE
Enhance pkg-builder script (#425)

### DIFF
--- a/build/ubuntu-22.04/pkg-builder
+++ b/build/ubuntu-22.04/pkg-builder
@@ -23,12 +23,24 @@ build_docker_image() {
     docker build -t "${BUILDER}" docker-pkg-builder
 }
 
+# shellcheck disable=SC2086
 run_in_docker() {
-    docker run \
+    DOCKER_ARGS=" \
         -e http_proxy -e https_proxy -e no_proxy \
-        -v "${BUILD_DIR}":/root/build \
+        -v ${BUILD_DIR}:/root/build \
+        -w /root/build/ubuntu-22.04 \
+	--rm \
+    "
+
+    if [ $1 == "--shell" ]; then
+      docker run ${DOCKER_ARGS} \
+        -it \
+        "${BUILDER}" bash
+    else
+      docker run ${DOCKER_ARGS} \
         -i --entrypoint "/root/build/ubuntu-22.04/$1" \
-        "${BUILDER}"
+        "${BUILDER}" $2
+    fi
 }
 
 check_docker_cmd
@@ -36,4 +48,4 @@ check_user_in_docker
 build_docker_image
 
 # Run ansible-playbook within docker
-run_in_docker "$1"
+run_in_docker "$@"


### PR DESCRIPTION
Add argument --shell to allow getting access to shell inside the docker container It is useful for incremental and customized build

Support building guest packages separately.