### PR TITLE
kernel: limit pahole version

### DIFF
--- a/build/ubuntu-22.04/intel-mvp-tdx-kernel/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-tdx-kernel/build.sh
@@ -38,6 +38,7 @@ prepare() {
     cp "${CURR_DIR}"/linux-6.2.16/* "${SOURCE_DIR}" -fr
 
     sudo apt update
+    sudo apt install pahole=1.22-8 -y
     if [[ -f /etc/timezone ]]; then
         sudo DEBIAN_FRONTEND=noninteractive apt install tzdata -y
     else

--- a/build/ubuntu-22.04/intel-mvp-tdx-kernel/debian.master/control.stub.in
+++ b/build/ubuntu-22.04/intel-mvp-tdx-kernel/debian.master/control.stub.in
@@ -36,7 +36,7 @@ Build-Depends:
  dkms <!stage1>,
  curl <!stage1>,
  zstd [amd64 s390x] <!stage1>,
- pahole [amd64 arm64 armhf ppc64el s390x riscv64] | dwarves (>= 1.21) [amd64 arm64 armhf ppc64el s390x riscv64] <!stage1>,
+ pahole (<< 1.24) [amd64 arm64 armhf ppc64el s390x riscv64] | dwarves (>= 1.21) [amd64 arm64 armhf ppc64el s390x riscv64] <!stage1>,
 Build-Depends-Indep:
  xmlto <!stage1>,
  docbook-utils <!stage1>,

--- a/build/ubuntu-22.04/intel-mvp-tdx-kernel/debian/control
+++ b/build/ubuntu-22.04/intel-mvp-tdx-kernel/debian/control
@@ -37,7 +37,7 @@ Build-Depends:
  curl <!stage1>,
  zstd [amd64 s390x] <!stage1>,
  sharutils <!stage1>,
- pahole [amd64 arm64 armhf ppc64el s390x riscv64] | dwarves (>= 1.21) [amd64 arm64 armhf ppc64el s390x riscv64] <!stage1>,
+ pahole (<< 1.24) [amd64 arm64 armhf ppc64el s390x riscv64] | dwarves (>= 1.21) [amd64 arm64 armhf ppc64el s390x riscv64] <!stage1>,
 Build-Depends-Indep:
  xmlto <!stage1>,
  docbook-utils <!stage1>,


### PR DESCRIPTION
Fix "Load BTF from vmlinux: Invalid argument" caused by Ubuntu distro pahole update.