### PR TITLE
pycloudstack: Support to set driver name for performance test

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -91,6 +91,7 @@ class VMGuest:
         vtpm_path=None,
         vtpm_log=None,
         hugepage_path=None,
+        driver=None
     ):
 
         self.vmid = vmid
@@ -123,6 +124,7 @@ class VMGuest:
         self.vtpm_path = vtpm_path
         self.vtpm_log = vtpm_log
         self.hugepage_path = hugepage_path
+        self.driver = driver
 
         self.vmm = vmm_class(self)
         if isinstance(self.vmm, VMMKubeVirt):
@@ -496,6 +498,7 @@ class VMGuestFactory:
         vtpm_path=None,
         vtpm_log=None,
         hugepage_path=None,
+        driver=None
     ):
         """
         Create a VM.
@@ -571,6 +574,7 @@ class VMGuestFactory:
             vtpm_path=vtpm_path,
             vtpm_log=vtpm_log,
             hugepage_path=hugepage_path,
+            driver=driver
         )
 
         self.vms[vm_name] = inst

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -181,6 +181,9 @@ class VMMLibvirt(VMMBase):
         if self.vminst.hugepages:
             xmlobj.set_hugepage_params(self.vminst.hugepage_size)
 
+        if self.vminst.driver:
+            xmlobj.set_driver(self.vminst.driver)
+
         if self.vminst.vsock:
             xmlobj.set_vsock(self.vminst.vsock_cid)
 


### PR DESCRIPTION
This change is for network performance test. User can set driver name other than using default vhost-net. 
1. virtxml.py: support to find an element via attribute value, and set driver name 
2. vmm.py: support to set driver name in xml template when it's specified 
3. vmguest.py: support to set driver when creating VM