### PR TITLE
kernel: allow pahole installation to downgrade version (#435)

### DIFF
--- a/build/ubuntu-22.04/intel-mvp-tdx-kernel/build.sh
+++ b/build/ubuntu-22.04/intel-mvp-tdx-kernel/build.sh
@@ -38,7 +38,7 @@ prepare() {
     cp "${CURR_DIR}"/linux-6.2.16/* "${SOURCE_DIR}" -fr
 
     sudo apt update
-    sudo apt install pahole=1.22-8 -y
+    sudo apt install pahole=1.22-8 -y --allow-downgrades
     if [[ -f /etc/timezone ]]; then
         sudo DEBIAN_FRONTEND=noninteractive apt install tzdata -y
     else


### PR DESCRIPTION
Allow the automatic downgrade of pahole during the installation, to also fix the "Load BTF from vmlinux: Invalid argument" issue on systems with an already newer pahole version.