### PR TITLE
pycloudstack: Only set numa in xml when it's set when VM is created

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -76,7 +76,7 @@ class VMGuest:
         vsock_cid=0,
         vmm_class=None,
         cpu_ids=None,
-        mem_numa=True,
+        mem_numa=None,
         io_mode=None,
         cache=None,
         diskfile_path=None,
@@ -498,7 +498,8 @@ class VMGuestFactory:
         vtpm_path=None,
         vtpm_log=None,
         hugepage_path=None,
-        driver=None
+        driver=None,
+        mem_numa=None
     ):
         """
         Create a VM.
@@ -574,7 +575,8 @@ class VMGuestFactory:
             vtpm_path=vtpm_path,
             vtpm_log=vtpm_log,
             hugepage_path=hugepage_path,
-            driver=driver
+            driver=driver,
+            mem_numa=mem_numa
         )
 
         self.vms[vm_name] = inst

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -176,6 +176,8 @@ class VMMLibvirt(VMMBase):
 
         if self.vminst.cpu_ids:
             xmlobj.bind_cpuids(self.vminst.cpu_ids)
+
+        if self.vminst.mem_numa is not None:
             xmlobj.set_mem_numa(self.vminst.mem_numa)
 
         if self.vminst.hugepages:


### PR DESCRIPTION
Method set_mem_numa is used to bind with cpuids which is not necessary. Whether to set_mem_numa should depend on the value of vminst.mem_numa which is set when VM is created.