### PR TITLE
Update TD security launch policy to turn off debug

### DIFF
--- a/doc/tdx_libvirt_direct.ubuntu_host.xml.template
+++ b/doc/tdx_libvirt_direct.ubuntu_host.xml.template
@@ -50,7 +50,7 @@
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
-    <policy>0x10000001</policy>
+    <policy>0x10000000</policy>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-cpu'/>

--- a/doc/tdx_libvirt_direct.xml.template
+++ b/doc/tdx_libvirt_direct.xml.template
@@ -52,7 +52,7 @@
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
-    <policy>0x10000001</policy>
+    <policy>0x10000000</policy>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-cpu'/>

--- a/doc/tdx_libvirt_grub.ubuntu_host.xml.template
+++ b/doc/tdx_libvirt_grub.ubuntu_host.xml.template
@@ -48,7 +48,7 @@
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
-    <policy>0x10000001</policy>
+    <policy>0x10000000</policy>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-cpu'/>

--- a/doc/tdx_libvirt_grub.xml.template
+++ b/doc/tdx_libvirt_grub.xml.template
@@ -50,7 +50,7 @@
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
-    <policy>0x10000001</policy>
+    <policy>0x10000000</policy>
   </launchSecurity>
   <qemu:commandline>
     <qemu:arg value='-cpu'/>

--- a/utils/pycloudstack/pycloudstack/templates/tdx-base-perf.xml
+++ b/utils/pycloudstack/pycloudstack/templates/tdx-base-perf.xml
@@ -77,6 +77,6 @@
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
-    <policy>0x10000001</policy>
+    <policy>0x10000000</policy>
   </launchSecurity>
 </domain>

--- a/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
+++ b/utils/pycloudstack/pycloudstack/templates/tdx-base.xml
@@ -61,6 +61,6 @@
   </devices>
   <allowReboot value='no'/>
   <launchSecurity type='tdx'>
-    <policy>0x10000001</policy>
+    <policy>0x10000000</policy>
   </launchSecurity>
 </domain>


### PR DESCRIPTION
1. Update pycloudstack xml template for TD to turn off debug by default
2. Update xml templates in doci to turn off debug by default