### PR TITLE
pycloudstack: Update vTPM

### DIFF
--- a/utils/pycloudstack/pycloudstack/vmguest.py
+++ b/utils/pycloudstack/pycloudstack/vmguest.py
@@ -13,7 +13,7 @@ import libvirt
 from .cmdrunner import SSHCmdRunner, NativeCmdRunner
 from .dut import DUT
 from .vmimg import VMImage
-from .vmm import VMMLibvirt, VMMKubeVirt
+from .vmm import VMMLibvirt
 from .vmparam import (
     VM_TYPE_TD,
     VM_TYPE_TD_PERF,
@@ -126,9 +126,6 @@ class VMGuest:
         self.hugepage_path = hugepage_path
         self.driver = driver
 
-        self.vmm = vmm_class(self)
-        if isinstance(self.vmm, VMMKubeVirt):
-            return
         # Update rootfs in kernel command line depending on distro
         rootfs_ubuntu = "root=/dev/vda1"
         rootfs_centos = "root=/dev/vda3"
@@ -144,6 +141,8 @@ class VMGuest:
             assert self.kernel is not None
             assert os.path.exists(self.kernel)
             self.kernel = os.path.realpath(self.kernel)
+
+        self.vmm = vmm_class(self)
 
     def ssh_run(self, cmdarr, ssh_id_key, no_wait=False):
         """

--- a/utils/pycloudstack/pycloudstack/vmm.py
+++ b/utils/pycloudstack/pycloudstack/vmm.py
@@ -39,7 +39,6 @@ from .vmparam import (
     VM_TYPE_TD_PERF,
     VM_TYPE_EFI_PERF,
     VM_TYPE_LEGACY_PERF,
-    BIOS_OVMF_VTPM,
 )
 
 __author__ = "cpio"
@@ -215,7 +214,6 @@ class VMMLibvirt(VMMBase):
         """
         if self.vminst.vmtype in [VM_TYPE_TD, VM_TYPE_TD_PERF]:
             xmlobj.set_vtpm_param(self.vminst.vtpm_path, self.vminst.vtpm_log)
-            xmlobj.loader = BIOS_OVMF_VTPM
 
     def _set_cpu_params_xml(self, xmlobj):
         """

--- a/utils/pycloudstack/pycloudstack/vmparam.py
+++ b/utils/pycloudstack/pycloudstack/vmparam.py
@@ -31,11 +31,8 @@ BIOS_BINARY_LEGACY_UBUNTU = "/usr/share/seabios/bios.bin"
 # Installed from the package of intel-mvp-qemu-kvm
 BIOS_OVMF = "/usr/share/qemu/OVMF.fd"
 
-# OVMF for vTPM
-BIOS_OVMF_VTPM = "/usr/share/tdx-vtpm/OVMF.fd"
-
 # vTPM TD binary file
-VTPM_PATH = "/usr/share/tdx-vtpm/final.bin"
+VTPM_PATH = "/usr/share/tdx-vtpm/vtpmtd.bin"
 
 VM_STATE_RUNNING = "running"
 VM_STATE_PAUSE = "paused"


### PR DESCRIPTION
1. Single OVMF binary for either with vTPM or not
2. Fix kernel cmdline cannot be passed to xml issue introduced by vmm early initialization