### PR TITLE
build: update cloud init user data to add tmpfiles.d config for CCNP

### DIFF
--- a/build/ubuntu-22.04/guest-image/cloud-init-data/user-data-basic/cloud-config-base-template.yaml
+++ b/build/ubuntu-22.04/guest-image/cloud-init-data/user-data-basic/cloud-config-base-template.yaml
@@ -27,7 +27,7 @@ write_files:
     SUBSYSTEM=="misc",KERNEL=="tdx-guest",MODE="0666"
   path: /etc/udev/rules.d/90-tdx.rules
 - content: |
-    D /run/ccnp/uds 0666 - - -
+    D /run/ccnp/uds 0757 - - -
   path: /usr/lib/tmpfiles.d/ccnp.conf
 
 power_state:

--- a/build/ubuntu-22.04/guest-image/cloud-init-data/user-data-basic/cloud-config-base-template.yaml
+++ b/build/ubuntu-22.04/guest-image/cloud-init-data/user-data-basic/cloud-config-base-template.yaml
@@ -26,6 +26,9 @@ write_files:
 - content: |
     SUBSYSTEM=="misc",KERNEL=="tdx-guest",MODE="0666"
   path: /etc/udev/rules.d/90-tdx.rules
+- content: |
+    D /run/ccnp/uds 0666 - - -
+  path: /usr/lib/tmpfiles.d/ccnp.conf
 
 power_state:
   delay: now

--- a/build/ubuntu-22.04/guest-image/create-ubuntu-image.sh
+++ b/build/ubuntu-22.04/guest-image/create-ubuntu-image.sh
@@ -313,7 +313,7 @@ create_user_data() {
         GUEST_REPO_NAME=$(basename $(realpath ${GUEST_REPO}))
         guest_repo_source='deb [trusted=yes] file:/srv/'$GUEST_REPO_NAME'/ jammy/all/\ndeb [trusted=yes] file:/srv/'$GUEST_REPO_NAME'/ jammy/amd64/'
         if [ -z $KERNEL_VERSION ]; then
-            kernel=$(tree ${GUEST_REPO} | grep linux-image-unsigned | head -1 | awk '{print $3}')
+            kernel=$(basename $(find $GUEST_REPO -name linux-image-unsigned* | head -1))
             KERNEL_VERSION=$(echo $kernel | awk -F'_' '{print $1}')
             KERNEL_VERSION=$(echo ${KERNEL_VERSION#linux-image-unsigned-})
         fi


### PR DESCRIPTION
update cloud init user data to add tmpfiles.d config to create CCNP required directory with correct permission in /run directory

Signed-off-by: Hairong Chen hairong.chen@intel.com