### PR TITLE
utils/ovmfkeyenroll: add ovmfvarenroll and update key parameters

### DIFF
--- a/utils/ovmfkeyenroll/ovmfkeyenroll/var_enroll.py
+++ b/utils/ovmfkeyenroll/ovmfkeyenroll/var_enroll.py
@@ -326,6 +326,7 @@ class VariableTimeBasedAuth:
         print("    Monotonic Cnt  : 0x%x" % self.count)
         print("    PubKey Index   : 0x%x" % self.pk_index)
         print("    TimeStamp      : %s" % self.time_stamp.dump())
+        print("    Data (hex)     : %s" % self.data.hex())
 
 
 class VariableStore:
@@ -952,7 +953,7 @@ def main():
         help="Print the variable info in the FD")
 
     argparser.add_argument(
-        '-f', "--fd",
+        '-f', "--input",
         help="The input FD file")
 
     argparser.add_argument(

--- a/utils/ovmfkeyenroll/pyproject.toml
+++ b/utils/ovmfkeyenroll/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ovmfkeyenroll"
-version = "1.2.0"
+version = "1.2.1"
 authors = [
   { name="Xu, Min", email="min.m.xu@intel.com" },
   { name="Feng, Jialei", email="jialei.feng@intel.com" },
 ]
 readme = "README.md"
-description = "OVMF PK, KEK and DB Keys Enrolling"
+description = "OVMF PK, KEK and DB Keys and Variables Enrolling"
 requires-python = ">=3.6.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -27,3 +27,4 @@ classifiers = [
 
 [project.scripts]
 ovmfkeyenroll = "ovmfkeyenroll.secure_boot:main"
+ovmfvarenroll = "ovmfkeyenroll.var_enroll:main"


### PR DESCRIPTION
- Add ovmfvarenroll tool to enroll normal variables to OVMF.
- Update ovmfkeyenroll parameters PK/KEK/db/dbx to optional, making the usage more flexible.