### PR TITLE
td-migration: support virtio-serial for MigTD

### DIFF
--- a/.github/workflows/.aspell.en.pws
+++ b/.github/workflows/.aspell.en.pws
@@ -405,3 +405,4 @@ ESXi
 CVE
 PCKIDRetrieval
 pckcache
+socat

--- a/utils/td-migration/README.md
+++ b/utils/td-migration/README.md
@@ -31,11 +31,18 @@ TD migration supports several features as below. The scripts described later wil
     sudo ./mig-td.sh -t dst
     ```
 
-    Use `-m` parameter to set the alternative path of `migtd.bin`.
+    1. Use `-m` parameter to set the alternative path of `migtd.bin`.
 
-    ```bash
-    sudo ./mig-td.sh -m path/to/migtd.bin -t src
-    ```
+        ```bash
+        sudo ./mig-td.sh -m path/to/migtd.bin -t src
+        ```
+
+    2. Use `-s` to enable virtio-serial instead of vsock
+
+        ```bash
+        sudo ./mig-td.sh -t src -s
+        sudo ./mig-td.sh -t dst -s
+        ```
 
     If MigTD starts successfully, the console will display the below message.
 
@@ -85,6 +92,8 @@ TD migration supports several features as below. The scripts described later wil
 - Pre-Migration
 
     Wait a while for source and destination TDs to be ready. Before starting pre-migration, create a channel between source and destination side migration TDs.
+
+    **Note: if use the virtio-serial mode to launch MigTD, the step of connecting to socat can be ignored.**
 
     ```bash
     sudo ./connect.sh
@@ -292,7 +301,6 @@ It supports to pre-binding a user TD with `migtd_hash` in case `migTD` is not cr
     ```console
     $ dmesg
     [110983.886989] migration flow is done, userspace pid 397008
-    ```
 
 ## 3. Related Specification
 

--- a/utils/td-migration/pre-mig.sh
+++ b/utils/td-migration/pre-mig.sh
@@ -70,7 +70,7 @@ pre_mig(){
         if [[ ${BIND} == true ]]; then
             ssh root@"${DEST_IP}" -o ConnectTimeout=30 "echo qom-set /objects/tdx0/ migtd-pid ${DST_MIGTD_PID} | nc -U /tmp/qmp-sock-dst -w3"
         fi
-       ssh root@"${DEST_IP}" -o ConnectTimeout=30 "echo qom-set /objects/tdx0/ vsockport ${VSOCK_PORT_DST} | nc -U /tmp/qmp-sock-dst"
+       ssh root@"${DEST_IP}" -o ConnectTimeout=30 "echo qom-set /objects/tdx0/ vsockport ${VSOCK_PORT_DST} | nc -U /tmp/qmp-sock-dst -w3"
     fi
 
     # Asking migtd-dst to connect to the src socat


### PR DESCRIPTION
Normally, MigTD use vsock as the default way to do pre-migration.
Now, add the virtio-serial support as an alternative way.