### PR TITLE
fix the typo of firmwarevolume in comments

### DIFF
--- a/utils/ovmfkeyenroll/ovmfkeyenroll/var_enroll.py
+++ b/utils/ovmfkeyenroll/ovmfkeyenroll/var_enroll.py
@@ -78,7 +78,7 @@ class FirmwareVolume:
         UCHAR: FileSystemGUID[16]
         UINT64: Length
         UINT32: Signature (_FVH)
-        UINT8: Attribute mask
+        UINT32: Attribute mask
         UINT16: Header Length
         UINT16: Checksum
         UINT16: ExtHeaderOffset


### PR DESCRIPTION
The type of firmwarevolume attributes is uint32 not uint8
```c
typedef UINT32 EFI_FVB_ATTRIBUTES_2;
```