### PR TITLE
Bug fix: fails to correctly detect TDX guest

### DIFF
--- a/utils/check-tdx-guest.sh
+++ b/utils/check-tdx-guest.sh
@@ -4,7 +4,7 @@
 #
 
 tdx_cpuinfo=$(grep -o tdx_guest /proc/cpuinfo)
-if [[ $tdx_cpuinfo != "tdx_guest" ]]; then
+if [[ $tdx_cpuinfo =~ "tdx_guest$" ]]; then
   echo "This is NOT a TDX guest!"
   echo "No config in cpuinfo!"
   exit 1


### PR DESCRIPTION
Updated line 7 of the script to be able to correctly detect TDX guests. In some platforms where the string "tdx_guest" appears multiple times as the output of "grep -o tdx_guest /proc/cpuinfo", earlier comparison that checked equality failed. 

![Screenshot from 2024-03-14 10-02-11](https://github.com/intel/tdx-tools/assets/154336341/5c2a7bdd-731e-4c2c-a3f1-52bc049dc691)
![Screenshot from 2024-03-14 09-59-08](https://github.com/intel/tdx-tools/assets/154336341/f113ae56-16ed-4d07-8efc-d5a2d6fb0a7e)


This fix will solve that bug and the script will be able to correctly detect a TDX guest in those platforms as well as others.